### PR TITLE
v5 round-out: ED-discipline standard + 6 new skills + 3 ED patches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Read each of these files — they contain the engineering rules and conventions 
 | [standards/database.md](standards/database.md) | SQL Server conventions, primary keys, timestamps, migrations |
 | [standards/documentation.md](standards/documentation.md) | XML docs, architecture docs (dual-format md + draw.io) |
 | [standards/dotnet.md](standards/dotnet.md) | .NET runtime, Minimal APIs, Dapper, DbUp, DI conventions |
+| [standards/engineering-discipline.md](standards/engineering-discipline.md) | How to work: grounded claims + adversarial self-review (ED-1..ED-4) |
 | [standards/error-handling.md](standards/error-handling.md) | Error responses, HTTP status codes, validation, pagination |
 | [standards/git-workflow.md](standards/git-workflow.md) | Branching, commits, PR process |
 | [standards/logging.md](standards/logging.md) | Serilog, log levels, correlation IDs, health checks |
@@ -123,6 +124,17 @@ The seven **pipeline** skills are now **v5** (four-tier model + TR enforcement �
 | File | Purpose |
 |------|---------|
 | [templates/CLAUDE-project.md](templates/CLAUDE-project.md) | Template CLAUDE.md for new projects — copy and fill in project-specific sections |
+
+---
+
+## How To Work (Universal)
+
+These habits apply to **every task on every project** — see [standards/engineering-discipline.md](standards/engineering-discipline.md) for the full rules (ED-1..ED-4):
+
+- **Confirm, don't guess (ED-1).** Trace any claim about how the code behaves to an observed `file:line` before writing it as fact. A plausible model is a hypothesis, not a fact.
+- **Falsify, don't rubber-stamp (ED-2).** Treat your own just-produced spec/ticket/PR as a suspect — try to break each claim before finalizing it.
+- **Label hypotheses (ED-3).** An ungrounded claim is written as a hypothesis with the evidence needed to settle it, never as established fact.
+- **Surface scope forks (ED-4).** If the chosen approach changes blast radius or which test tiers apply, say so — never let a ticket hide it.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,28 +94,28 @@ Read each of these files — they contain the engineering rules and conventions 
 
 Shared skills live in `skills/` and are auto-copied to each project's `.claude/skills/` during sync. Projects can override any skill by placing a customized version in their own `.claude/skills/` directory.
 
-The seven **pipeline** skills are now **v5** (four-tier model + TR enforcement — see [standards/testing.md](standards/testing.md)) — the six test-pipeline skills plus the mode-switching `orchestrate-v5`. The other skills are unchanged at v4.
+**All pipeline and authoring skills are now v5** (four-tier model + TR enforcement — see [standards/testing.md](standards/testing.md)) and apply the grounded + adversarial **engineering discipline** (ED-1..ED-4 — see [standards/engineering-discipline.md](standards/engineering-discipline.md)). The ticket-producing skills end with a three-part contribution step (what we missed / should consider / I'd add).
 
 | Skill | Purpose |
 |-------|---------|
-| [skills/prd-to-backlog-v4/SKILL.md](skills/prd-to-backlog-v4/SKILL.md) | Decompose a PRD into a milestoned backlog of vertical-slice stories |
-| [skills/add-story-v4/SKILL.md](skills/add-story-v4/SKILL.md) | Conversationally create incremental stories for an existing project |
-| [skills/refine-story-v5](skills/refine-story-v5/SKILL.md) | Refine a GitHub issue into an implementation-ready spec with a behavior-first test plan (one tier per behavior, critical journeys declared) |
+| [skills/prd-to-backlog-v5/SKILL.md](skills/prd-to-backlog-v5/SKILL.md) | Decompose a PRD into a milestoned backlog of vertical-slice stories; nominates the repo-wide critical-path journeys; three-part contribution |
+| [skills/add-story-v5/SKILL.md](skills/add-story-v5/SKILL.md) | Conversationally create incremental stories for an existing project; three-part contribution; non-interactive mode for callers |
+| [skills/refine-story-v5](skills/refine-story-v5/SKILL.md) | Refine a GitHub issue into an implementation-ready spec with a behavior-first test plan (one tier per behavior, critical journeys declared); adversarial self-review (ED-2) in all modes |
 | [skills/implement-ticket-v5](skills/implement-ticket-v5/SKILL.md) | Implement a single ticket — writes Unit + Contract tests per the tier table (no logic in Contract). Pushes branch, creates PR. Supports FIX mode |
 | [skills/engineering-review-v5](skills/engineering-review-v5/SKILL.md) | Review a PR against standards. Three modes; enforces tiers two-way (missing + redundant), counts critical-path, emits the TR checklist grid |
-| [skills/security-review-v4](skills/security-review-v4/SKILL.md) | OWASP Top 10 + infrastructure security review for PRs |
+| [skills/security-review-v5](skills/security-review-v5/SKILL.md) | OWASP Top 10 + infrastructure security review for PRs; fail-open / silent-error check |
 | [skills/integration-test-v5](skills/integration-test-v5/SKILL.md) | Write integration tests for a merged implementation — real-infra behavior only (no contract re-assertion). Creates PR. Supports FIX mode |
 | [skills/ui-test-v5](skills/ui-test-v5/SKILL.md) | Write Playwright UI tests — journey-scoped, conditional, critical-path tagged. Runs via scoped `workflow_dispatch` on the self-hosted runner. Creates PR. Supports FIX mode |
 | [skills/orchestrate-v5/SKILL.md](skills/orchestrate-v5/SKILL.md) | Mode-switching pipeline orchestrator (WORKING/CLEANUP) built for relaunch by the dumb loop; per-run tracking issue, board-driven queue, TR gate-audit, observability |
 | [skills/ci-fix-v5](skills/ci-fix-v5/SKILL.md) | Monitor GitHub Actions and auto-fix CI/CD failures — fix the code, not the test. Background side-channel for orchestrator; standalone for ad-hoc repair |
 | [skills/monitor-v5](skills/monitor-v5/SKILL.md) | Read-only live narrator for an orchestration run — interpretive play-by-play off the tracking issue + work tickets + CI (stage/PR/CLEANUP events, stall flags). Observe-only companion to the dumb-driver heartbeat; never writes |
-| [skills/reconcile-backlog-v4](skills/reconcile-backlog-v4/SKILL.md) | Reconcile PRD version changes against an existing backlog and codebase. Diffs, classifies, and executes creates/updates |
-| [skills/triage-v4](skills/triage-v4/SKILL.md) | Interactive investigation and bug triage — never writes code, output is always a ticket |
-| [skills/conformance-v4](skills/conformance-v4/SKILL.md) | Audit a project against TI Engineering Standards — informational only, produces a gap report |
+| [skills/reconcile-backlog-v5](skills/reconcile-backlog-v5/SKILL.md) | Reconcile PRD version changes against an existing backlog and codebase. Diffs, classifies (grounded in source), and executes via add-story-v5 + refine-story-v5 |
+| [skills/triage-v5](skills/triage-v5/SKILL.md) | Interactive investigation and bug triage — evidence-first runtime diagnosis (pull the real exception before theorizing), never writes code, output is always a ticket |
+| [skills/conformance-v5](skills/conformance-v5/SKILL.md) | Audit a project against TI Engineering Standards incl. the v5 four-tier test model — informational only, produces a gap report |
 
 > **Note:** v1, v2, and v3 skills remain in `skills/archive/` for historical reference but are no longer actively maintained.
 >
-> **v4 → v5 transition:** the v4 copies of the seven rebuilt skills (`refine-story-v4`, `implement-ticket-v4`, `integration-test-v4`, `ui-test-v4`, `engineering-review-v4`, `ci-fix-v4`, `orchestrate-v4`) **remain in `skills/`** and are still synced — v4 keeps running until v5 is proven on the pilot (Phase 5). Only then do the v4 copies move to `skills/archive/`.
+> **v4 → v5 transition:** the v4 copies of the rebuilt skills **remain in `skills/`** and are still synced — v4 keeps running until v5 is proven on the pilot. Only then do the v4 copies move to `skills/archive/`. The round-out (the six authoring/audit skills: `prd-to-backlog-v5`, `add-story-v5`, `reconcile-backlog-v5`, `triage-v5`, `conformance-v5`, `security-review-v5`) plus the ED-discipline patches to `refine-story-v5` / `implement-ticket-v5` / `engineering-review-v5` are tracked in [notes/v5-round-out-plan.md](notes/v5-round-out-plan.md).
 
 ---
 

--- a/notes/v5-round-out-plan.md
+++ b/notes/v5-round-out-plan.md
@@ -5,7 +5,7 @@
 > rebuilt the **eight pipeline skills** to the four-tier + TR model. This plan covers the
 > **six remaining v4-only skills** — giving each a v5 that inherits the established v5 "ways"
 > plus one new cross-cutting pattern (the three-part proactive contribution step).
-> **Created:** 2026-06-26. **Status:** LOCKED — ready to execute (decisions resolved; build all at once).
+> **Created:** 2026-06-26. **Status:** EXECUTED 2026-06-27 on branch `v5-round-out-plan` (PR #5) — standard + 6 new skills + 3 ED patches built. Awaiting review/merge.
 > **Principle (carried over):** **define → seed → enforce**, single source of truth in
 > `standards/testing.md`, cite TR by ID, never restate.
 
@@ -164,11 +164,11 @@ Encode Pattern 0 as a standard so it reaches every project/instance from source:
 - The local memory entry (`grounded-and-adversarial`) stays as a personal stopgap, but the **standard
   is the source of truth**.
 
-## Still to confirm (non-blocking)
-- **Patterns G + D on the *other* existing v5 skills** (`implement-ticket-v5`, `engineering-review-v5`).
-  Recommended yes (the discipline is universal; engineering-review already has partial adversarial DNA
-  via the phantom-AC check) — but it expands blast radius beyond the six + refine. **Not auto-included;**
-  confirm before touching impl/review so we don't quietly balloon scope.
+## Resolved (was "still to confirm")
+- **Patterns G + D on the other existing v5 skills** (`implement-ticket-v5`, `engineering-review-v5`):
+  **CONFIRMED yes** (Kevin, 2026-06-27 — "patch everything"). Both patched: implement gets step 4.5
+  adversarial self-review (ED-2); engineering-review gets the Ungrounded Claim / Data-Flow check (ED-1)
+  and the ED-tagged phantom-AC check.
 
 ## Build footprint (what will change when we execute)
 - **Foundational (first):** new `standards/engineering-discipline.md` (ED-1..ED-4) + `CLAUDE.md`

--- a/notes/v5-round-out-plan.md
+++ b/notes/v5-round-out-plan.md
@@ -139,6 +139,30 @@ the orchestrator may inject follow-ups), support a non-interactive path with bes
 4. **Build order doesn't matter — build all at once.** Each new `-v5` scaffolds as a verbatim copy of
    its v4 origin first (so each per-skill edit diffs cleanly against v4), per the original v5 build
    convention. refine-story-v5 is patched in place against its current state.
+5. **Grounded + adversarial is encoded as a STANDARD, not just skill behavior.** Memory does not
+   propagate (it's local to one repo path / machine / instance); the standards repo + skills do, via
+   auto-sync. So Pattern 0 lives in a source-of-truth standards file and the skills **cite it by ID**
+   — the same `define → seed → enforce` shape as the TR rules. Without this, "every instance gets the
+   habit on v5 upgrade" doesn't actually hold. (Kevin, 2026-06-26.)
+
+## Foundational work item — the propagation backbone (do FIRST)
+Encode Pattern 0 as a standard so it reaches every project/instance from source:
+- **New `standards/engineering-discipline.md`** — universal working discipline, citeable rule IDs
+  mirroring `TR-n`:
+  - **ED-1 — Grounded claims.** Trace any factual claim about code behavior to an observed
+    `file:line` before writing it as fact; unverified = labeled hypothesis.
+  - **ED-2 — Adversarial self-review.** Treat your own just-produced output as a suspect; try to
+    falsify each claim before finalizing.
+  - **ED-3 — Hypothesis vs. conclusion labeling.** A claim without grounding evidence is written as
+    a hypothesis with "evidence needed: …", never as established fact.
+  - **ED-4 — Scope-fork detection.** Check whether the chosen approach silently changes blast radius
+    or which test tiers apply; surface the fork instead of hiding it.
+- **Index it in `CLAUDE.md`** Standards Index table + a short "How To Work (Universal)" block for
+  salience.
+- v5 skills **cite `ED-1`/`ED-2`/etc. by ID** (never restate). The plan's "Patterns G/D" are the
+  skill-side application of `ED-1`/`ED-2`.
+- The local memory entry (`grounded-and-adversarial`) stays as a personal stopgap, but the **standard
+  is the source of truth**.
 
 ## Still to confirm (non-blocking)
 - **Patterns G + D on the *other* existing v5 skills** (`implement-ticket-v5`, `engineering-review-v5`).
@@ -147,9 +171,14 @@ the orchestrator may inject follow-ups), support a non-interactive path with bes
   confirm before touching impl/review so we don't quietly balloon scope.
 
 ## Build footprint (what will change when we execute)
-New skill dirs (scaffold-from-v4 then edit): `add-story-v5`, `prd-to-backlog-v5`, `triage-v5`,
-`reconcile-backlog-v5`, `conformance-v5`, `security-review-v5`. Patched in place: `refine-story-v5`.
-Plus `CLAUDE.md` skills-table re-point once each lands. **This plan doc is the only change so far.**
+- **Foundational (first):** new `standards/engineering-discipline.md` (ED-1..ED-4) + `CLAUDE.md`
+  Standards-Index entry and "How To Work (Universal)" block.
+- New skill dirs (scaffold-from-v4 then edit): `add-story-v5`, `prd-to-backlog-v5`, `triage-v5`,
+  `reconcile-backlog-v5`, `conformance-v5`, `security-review-v5`.
+- Patched in place: `refine-story-v5`.
+- `CLAUDE.md` skills-table re-point once each lands.
+
+**This plan doc is the only change so far.**
 
 ---
 

--- a/notes/v5-round-out-plan.md
+++ b/notes/v5-round-out-plan.md
@@ -1,0 +1,198 @@
+# v5 Round-Out Plan
+
+> **Purpose:** finish the v5 skill suite. The initial v5 build
+> ([`v5-implementation-plan.md`](v5-implementation-plan.md) + [`v5-changes.md`](v5-changes.md))
+> rebuilt the **eight pipeline skills** to the four-tier + TR model. This plan covers the
+> **six remaining v4-only skills** — giving each a v5 that inherits the established v5 "ways"
+> plus one new cross-cutting pattern (the three-part proactive contribution step).
+> **Created:** 2026-06-26. **Status:** LOCKED — ready to execute (decisions resolved; build all at once).
+> **Principle (carried over):** **define → seed → enforce**, single source of truth in
+> `standards/testing.md`, cite TR by ID, never restate.
+
+---
+
+## Skills needing a v5
+
+| Skill | Type | v5 effort |
+|---|---|---|
+| `add-story-v5` | additive / interactive (writes tickets) | Medium |
+| `prd-to-backlog-v5` | additive / batch (writes tickets) | Medium |
+| `triage-v5` | interactive / diagnostic (writes tickets) | Medium |
+| `reconcile-backlog-v5` | orchestrates add-story + refine | Low (re-point + inherit) |
+| `conformance-v5` | read-only audit | High (audit the new testing standard) |
+| `security-review-v5` | reviewer | Low / TBD (orthogonal to testing overhaul) |
+
+`monitor-v5` is already v5-native (no v4 origin). The other eight pipeline skills are done.
+
+---
+
+## Cross-cutting v5 patterns to apply
+
+### 0. Grounded + adversarial discipline (confirm, don't guess; falsify, don't rubber-stamp)
+The observed failure mode of Opus 4.8 in this dev process: it **reasons forward from a plausible
+model and asserts it without confirming** — sending real effort down confident-but-wrong paths.
+Two distinct, paired mechanisms; they fail together, so we bake in both:
+
+- **Pattern G — Grounded claims.** Any factual claim about how the code behaves (what a
+  type/payload contains, what an endpoint returns, what an effect is keyed on, where a value flows)
+  must be traced to an **observed source location (`file:line`)** before it's written as fact.
+  Unverified = labeled a **hypothesis** ("assumed; not yet traced to source"), never shipped as
+  established. Generalizes triage's hypothesis-vs-conclusion guard (#4) beyond runtime errors.
+- **Pattern D — Adversarial self-review.** A mandatory step that treats your **own just-produced**
+  spec/ticket as a suspect to cross-examine, not a product to defend. Re-trace every asserted data
+  flow / type / contract to source and try to **prove it wrong**. Reframes the existing
+  confirmatory gap-analysis ("review for gaps") into a falsifying one ("attempt to break each
+  claim I just made").
+
+Why both: the **adversarial posture decides *what* to re-check; the grounding standard decides
+*whether it's true*.** Adversarial-without-grounding "corrects" right things into wrong ones;
+grounded-without-adversarial never doubts the confident-but-wrong claims (the ones that *feel*
+obviously right — exactly the class that slips through).
+
+Pipeline: **ground → adversarially attack → surface (the three-part contribution step) → escalate
+genuine forks.**
+
+Specifics to capture in each skill:
+- **Scope-fork detection** — does the chosen approach secretly change blast radius or which test
+  tiers apply? (From the real example: a "frontend-only" fix whose option (c) re-introduced the
+  .NET tiers the ticket said didn't apply.)
+- **Headless behavior** — G and D need source access, not a human, so they run **always**
+  (including `ORCHESTRATOR_MODE`). Only the *escalation of a genuine scope-fork* is gated: headless,
+  default to the **smallest-scope** option **and** record the fork as a flag/follow-up — never
+  silently pick the big one.
+
+Motivating example (real interaction, current refine-story-v5): the first refine pass asserted a
+`overallGrade` data flow ("App captures it from `handleGenerateComplete`") it never traced to the
+type — the POST `RiskAssessmentResponse` doesn't carry that field; it only exists on the GET
+response. A second, *adversarial* pass grepped the type and collapsed the theory in ~2 minutes.
+**This means refine-story-v5 has the gap today** — see Open Decision #2 (patch refine, don't exempt it).
+
+### 1. Three-part proactive contribution step  ← the new headline pattern
+At a standing, near-final checkpoint, **Claude volunteers its own input on the ticket
+automatically** — because that's the question the team always asks Claude when writing a
+ticket. Three forward-looking parts:
+
+- **What we missed** — gaps Claude sees in the ticket
+- **What we should consider** — angles, options, risks worth raising
+- **What I'd add** — Claude's own recommendations to strengthen it
+
+Plus a fourth flavor, kept from refine's existing section: **what was considered and discarded**.
+
+Rules of the step:
+- Plain prose, **no taxonomy buckets**. Surfaced **without being asked**, every ticket.
+- Runs **just before** the ticket is finalized / written to GitHub.
+- **Skipped in `ORCHESTRATOR_MODE` / headless** (no human in the loop).
+- Applies to all ticket-producers: `add-story`, `prd-to-backlog`, `triage`, `reconcile-backlog`.
+- **Backport [DECISION PENDING]:** refine-story-v5 currently has only the narrow "auto-reveal
+  discarded" version (lines 203–207). Upgrade it to the fuller three-part version for consistency,
+  even though we agreed not to otherwise touch the existing v5 skills?
+
+### 2. Four-tier test vocabulary, cite TR by ID, never restate
+Drop the old 3-row `Unit / Integration / UI — Yes/N-A` template the v4 ticket-writers carry.
+Reference `standards/testing.md` and `TR-n` by ID only.
+
+### 3. Single owner for the behavior→tier table
+`refine-story-v5` owns the enforced behavior-first table (TR-1) + critical-path declaration
+(TR-6). Ticket-creators emit a **coarse one-line test intent** and **defer** the real table
+to refine. No duplication, no drift.
+
+### 4. `gh ... --limit 1000` guard
+Every board/issue listing — `gh` defaults to 30 and silently drops the newest items
+(e.g. a just-injected ticket sorts last). Same lesson already baked into orchestrate-v5.
+
+### 5. Non-interactive / `ORCHESTRATOR_MODE` path
+Where another skill or the orchestrator invokes headlessly (reconcile calls add-story;
+the orchestrator may inject follow-ups), support a non-interactive path with best-judgment defaults.
+
+---
+
+## Per-skill scope
+
+- **triage-v5** — three-part contribution as the closing step before ticket write; tag bugs on
+  auth/money/critical journeys for TR-6; four-tier vocab; `--limit` guard. Stays "never writes code."
+  **Plus evidence-first runtime diagnosis (see #4 below).**
+- **add-story-v5** — contribution step; defer tier table to refine; **callable non-interactive
+  mode** (reconcile + orchestrator follow-ups); `--limit` guard.
+- **prd-to-backlog-v5** — contribution step on the decomposition; **nominate the repo-wide
+  critical-path journeys** (ceiling 10) at backlog level so refine/ui-test draw from a budgeted
+  pool; `--limit` guard.
+- **reconcile-backlog-v5** — re-point Phase 5 to `add-story-v5` / `refine-story-v5`; contribution
+  step on classifications; `--limit` guard. Mostly inherits.
+- **conformance-v5** — audit the **new** testing standard: Contract tier exists & uses
+  WebApplicationFactory (TR-2 no-logic), inverted-pyramid / redundancy (TR-10), critical-path
+  count ≤ 10 / ≥ 3 (TR-6), no `Skip` / silent failures (TR-8), POM + condition-based waits (TR-9),
+  no Docker in fast tier (TR-11); audit CI tiering (`fast`/`integration`/`ui` workflows) and
+  orchestration vendoring (`scripts/orchestrate.sh`). Read-only; no contribution step.
+- **security-review-v5** — TBD. Light align (`--limit`, tracking-issue / event-log vocabulary,
+  fail-open / silent-provider-error overlap that engineering-review-v5 added) vs leave at v4.
+
+---
+
+## Decisions (LOCKED)
+1. **Patch existing v5 skills, don't just add.** The original "only add new v5 skills, don't touch
+   existing ones" rule is **superseded** — these things evolve, and the grounded+adversarial gap is
+   literally in `refine-story-v5` today. We **patch** where the standard has moved on. (Kevin, 2026-06-26.)
+2. **`refine-story-v5` gets patched** for Patterns G + D, and its narrow auto-reveal is upgraded to
+   the fuller three-part contribution step. It's the skill where the miss happened; it leads, not exempt.
+3. **security-review** → make `security-review-v5` (light v5 align: `--limit` guard, tracking-issue /
+   event-log vocabulary, fail-open / silent-provider-error overlap). Part of "do them all."
+4. **Build order doesn't matter — build all at once.** Each new `-v5` scaffolds as a verbatim copy of
+   its v4 origin first (so each per-skill edit diffs cleanly against v4), per the original v5 build
+   convention. refine-story-v5 is patched in place against its current state.
+
+## Still to confirm (non-blocking)
+- **Patterns G + D on the *other* existing v5 skills** (`implement-ticket-v5`, `engineering-review-v5`).
+  Recommended yes (the discipline is universal; engineering-review already has partial adversarial DNA
+  via the phantom-AC check) — but it expands blast radius beyond the six + refine. **Not auto-included;**
+  confirm before touching impl/review so we don't quietly balloon scope.
+
+## Build footprint (what will change when we execute)
+New skill dirs (scaffold-from-v4 then edit): `add-story-v5`, `prd-to-backlog-v5`, `triage-v5`,
+`reconcile-backlog-v5`, `conformance-v5`, `security-review-v5`. Patched in place: `refine-story-v5`.
+Plus `CLAUDE.md` skills-table re-point once each lands. **This plan doc is the only change so far.**
+
+---
+
+### Triage-only pattern: evidence-first runtime diagnosis  (the #4 bake-in)
+
+From a real triage miss (issue #3): a separate triage instance reasoned **forward from the
+symptom** ("reports fail → must be missing blob storage") and landed on a confident-but-wrong
+root cause that would have sent someone to "fix" already-correct bicep. The actual stack trace
+was sitting in Log Analytics the whole time — pulling it collapsed the theory in ~2 minutes and
+pointed straight at `MigraDocReportPdfRenderer:35`. The bug in the render path sat untouched
+while effort was aimed at correct infrastructure.
+
+Principle: **for a runtime failure, the cheapest disambiguating move is to retrieve the real
+exception before theorizing about infrastructure** — reason *backward from the error*, not
+*forward from the symptom*. (Same "lowest sufficient" instinct as the testing model, applied to
+diagnosis: a stack trace is near-free and decisive; an infra theory is expensive and speculative.)
+
+Bake into `triage-v5` as three concrete pieces:
+
+1. **Evidence-first investigation order.** When the symptom is a runtime failure (5xx, crash,
+   unhandled exception, worker dying), the FIRST move is to pull the actual exception + stack
+   trace from the **dev environment's runtime logs** — before any infrastructure hypothesis.
+   Add to the investigation toolkit: query Log Analytics / container-app logs
+   (`az containerapp logs show`, `az monitor log-analytics query`), not just local `docker logs`.
+
+2. **Attempt-and-surface, don't theorize past a gap.** Triage *attempts* to pull running logs;
+   if it can't (no creds/access, env down), it says so explicitly and marks the root cause
+   **unconfirmed** — it does NOT silently skip the log and reason forward anyway. Missing
+   evidence becomes a stated gap, not an invisible assumption. ("the ability, or at least the attempt")
+
+3. **Hypothesis vs. conclusion guard.** A root cause for a runtime error may be written as
+   *established* only if backed by an actual error line / stack trace; otherwise it is tagged a
+   **hypothesis** with "evidence needed: pull `<log>`". Analogous to engineering-review-v5's
+   phantom-acceptance-criteria check — stops a confident-but-wrong root cause from reaching the
+   ticket as fact.
+
+Dovetails with the three-part contribution step: "what we missed" naturally surfaces
+*"I theorized X but couldn't confirm — grab the exception at `<path>` first."*
+
+---
+
+## Observations integrated
+All three of Kevin's observations are folded in:
+1. The three-part proactive contribution step (Pattern 1).
+2. Evidence-first runtime diagnosis for triage (the #4 bake-in).
+3. Grounded + adversarial discipline (Pattern 0, Patterns G + D).

--- a/skills/add-story-v5/SKILL.md
+++ b/skills/add-story-v5/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: add-story-v5
+description: "Conversationally create one or more stories for an existing project. Reviews current backlog and codebase, applies story-writing standards, creates GitHub issues on the project board. Surfaces a three-part contribution before creating; supports a non-interactive mode for callers (reconcile / orchestrator)."
+argument-hint: "[description of what to add, or leave blank for interactive mode]"
+---
+
+# Add Story
+
+You are adding stories to an existing project backlog. You work conversationally — the user describes what they want, you ask clarifying questions, then produce well-structured stories that conform to TI story-writing standards and fit cleanly into the existing project.
+
+You do NOT implement anything. You produce stories.
+
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). When a story references how the existing code behaves (an entity, an endpoint, a screen, a pattern to follow), **ground it in the source (ED-1)** — don't assert from a plausible mental model. Before creating issues, adversarially re-check your proposal (ED-2) and **surface your own take** — what we missed / should consider / I'd add (Phase 3.5). Cite the ED rules by ID; do not restate them.
+
+**Mode:** Standalone/interactive by default. When invoked **non-interactively** by another skill (`reconcile-backlog-v5`) or the orchestrator — signalled by the caller passing a full story spec and `NONINTERACTIVE=true` — skip the clarifying questions (Phase 2) and the conversational surfacing in Phase 3.5; make best-judgment decisions from codebase patterns and fold the contribution items into the issue body instead. The grounding (ED-1) and adversarial self-review (ED-2) still run.
+
+## Phase 0: Load Context
+
+### 0a. Resolve Project Identity
+
+```bash
+REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+REPO_OWNER=$(echo "$REPO_NWO" | cut -d/ -f1)
+REPO_NAME=$(echo "$REPO_NWO" | cut -d/ -f2)
+```
+
+### 0b. Sync Standards & Read Config
+
+1. Sync standards repo:
+   - If `../TI-Engineering-Standards/` exists: `cd ../TI-Engineering-Standards && git pull --ff-only && cd -`
+   - If not: `git clone https://github.com/drdatarulz/TI-Engineering-Standards.git ../TI-Engineering-Standards/`
+2. **Read `../TI-Engineering-Standards/standards/story-writing-standards.md` in full**
+3. Read `../TI-Engineering-Standards/standards/project-tracking.md`
+4. Read `CLAUDE.md` — extract: story ID prefix, project board URL, build commands
+5. Read `ARCHITECTURE.md`
+
+### 0c. Understand Current State
+
+1. **Fetch open stories** for existing backlog context:
+   ```bash
+   # --limit is mandatory: gh defaults to 30 items and silently drops the rest on a mature board
+   gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state open --limit 1000 --json number,title,labels --jq '.[] | {number, title, labels: [.labels[].name]}'
+   ```
+
+2. **Fetch recent closed stories** (last 10) for pattern reference:
+   ```bash
+   gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state closed --label story --limit 10 --json number,title --jq '.[] | {number, title}'
+   ```
+
+3. **Scan the codebase** — understand what's built:
+   - `src/` directory structure — what projects/components exist
+   - Recent git log (`git log --oneline -20`) — what's been worked on
+   - Existing screens/pages if UI exists
+
+4. **Check for existing milestones:**
+   ```bash
+   gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state open --label milestone --json number,title --jq '.[] | {number, title}'
+   ```
+
+### 0d. Resolve Project Board IDs
+
+Query GraphQL for project ID, field ID, and status option IDs (same pattern as orchestrate-v4 Step 0c).
+
+---
+
+## Phase 1: Gather Requirements
+
+### If $ARGUMENTS contains a description:
+
+Parse the user's description and proceed to Phase 2 (Clarify).
+
+### If $ARGUMENTS is empty or minimal:
+
+Ask the user: **"What would you like to add to this project? Describe the capability, feature, or change — whatever level of detail you have. I'll ask follow-up questions if I need more."**
+
+---
+
+## Phase 2: Clarify
+
+Based on the user's description and your understanding of the codebase, identify gaps. Ask clarifying questions — max 2-3 questions per message, each focused:
+
+**Questions to consider (ask only what's needed):**
+- Does this affect an existing entity or introduce a new one?
+- Is this a new screen/page, or additions to an existing one?
+- Are there validation rules or business logic I should know about?
+- How does this relate to existing stories in the backlog?
+- Should this be its own milestone, or does it attach to an existing one?
+
+**Skip questions where:**
+- The codebase provides a clear answer
+- The existing patterns make the choice obvious
+- There's only one reasonable option
+
+---
+
+## Phase 3: Propose Stories
+
+Based on the user's input, existing codebase, and story-writing standards, propose one or more stories.
+
+Present each story in preview format before creating issues:
+
+```markdown
+## Proposed Stories
+
+### {Title}
+**Label:** story
+**Milestone:** {Existing milestone name | "New milestone: {name}" | "None — standalone review gate"}
+
+**Summary:** {1-2 sentences from user's perspective}
+
+**Acceptance Criteria:**
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+**Dependencies:** {None | list of story IDs that must be complete first}
+
+---
+
+### [additional stories if needed]
+
+---
+
+**This would create {N} issue(s). Want me to proceed, or adjust anything?**
+```
+
+**Sizing check:** Before proposing, verify each story against story-writing standards sizing guidance:
+- Is it a vertical slice (not a horizontal layer)?
+- Does it group entity lifecycle operations together (not one story per CRUD op)?
+- Is it completable in a single developer agent session?
+- Is it too large? Split along capability boundaries.
+
+Wait for user approval before creating issues.
+
+---
+
+## Phase 3.5: Adversarial Self-Review & Contribution
+
+Before creating anything, cross-examine your own proposal, then volunteer your take.
+
+**Adversarial self-review (ED-2) — runs in every mode.** Re-check each story against the source: do the entities, screens, endpoints, and "follow the existing pattern" references actually exist as described (ED-1)? Anything you couldn't confirm is flagged, not assumed (ED-3). Does any story silently change blast radius or pull in more than its slice implies (ED-4)?
+
+**Surface your own take (the three-part contribution) — interactive mode.** Volunteer this without being asked; it's the question the user always asks when writing a ticket. Plain prose, four parts:
+
+- **What we missed** — capabilities, edge cases, or dependencies the description didn't mention but the backlog/codebase implies
+- **What we should consider** — sequencing, milestone boundaries, alternatives to the proposed split
+- **What I'd add** — criteria or watch-outs that strengthen the stories
+- **What I considered and set aside** — splits/groupings weighed and rejected, with why
+
+In **non-interactive mode**, skip the conversational surfacing and fold these items into the issue body (a `## Notes` section) instead; a genuine scope-fork becomes a flagged follow-up rather than a silent choice.
+
+---
+
+## Phase 4: Create Issues
+
+After user approves:
+
+### 4a. Create Each Story Issue
+
+```bash
+ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
+  --title "{Title}" \
+  --label "story" \
+  --body "$(cat <<'EOF'
+## Summary
+
+{Description}
+
+{If milestone: **Milestone:** {Milestone Name}}
+
+## Acceptance Criteria
+
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+## Branch
+
+`story/{PREFIX}-{ISSUE_NUM}-short-name`
+
+## Test Coverage (intent — refine assigns tiers)
+
+Coarse intent only; `refine-story-v5` produces the enforced behavior-first tier table (one behavior, one tier — TR-1) and declares any critical-path journey (TR-6). Do not pre-assign tiers here. See `standards/testing.md`.
+
+- **Likely tiers:** {e.g. Unit for the logic, Contract for the endpoint wiring; Integration only if real-infra behavior; UI only if a user journey}
+- **Critical path?** {Yes — on an auth/money/core-journey path | No}
+
+## Plan
+
+_Fill in before starting implementation._
+
+## Implementation Notes
+
+_Fill in during implementation._
+
+## Test Results
+
+_Fill in when done._
+
+## Files Changed
+
+_Fill in when done._
+EOF
+)"
+```
+
+After creation:
+1. Extract the issue number from the URL: `ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '\d+$')`
+2. Update the title: `gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --title "{PREFIX}-${ISSUE_NUM}: {Title}"`
+3. Set custom fields (Type=Story, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`)
+4. Move to **Up Next**
+
+### 4b. Create Milestone Marker (If Needed)
+
+If the new stories warrant their own milestone (per story-writing standards or user request), create a milestone marker issue with the `milestone` label.
+
+**Ensure the `milestone` label exists** — if not, create it:
+```bash
+gh label create milestone --repo {REPO_OWNER}/{REPO_NAME} --description "Milestone marker issue (review gate)" --color "0E8A16"
+```
+
+### 4c. Link Stories as Sub-Issues of Milestone
+
+After creating all stories and the milestone marker, link each story as a sub-issue of the milestone. This gives epic-style progress tracking on the milestone issue.
+
+For each story in the milestone:
+
+1. Get the story's database ID:
+   ```bash
+   gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
+     repository(owner: $owner, name: $repo) { issue(number: $number) { databaseId } }
+   }' -f owner={REPO_OWNER} -f repo={REPO_NAME} -F number={STORY_ISSUE_NUMBER} --jq '.data.repository.issue.databaseId'
+   ```
+2. Add as sub-issue using the GitHub MCP `sub_issue_write` tool:
+   - `method`: `add`
+   - `owner`: `{REPO_OWNER}`
+   - `repo`: `{REPO_NAME}`
+   - `issue_number`: the milestone marker's issue number
+   - `sub_issue_id`: the story's database ID from step 1
+
+If adding stories to an **existing** milestone, use the same process — get the existing milestone's issue number and add the new stories as sub-issues.
+
+### 4d. Confirm
+
+Tell the user what was created:
+
+```markdown
+## Stories Created
+
+| # | Story ID | Title | Milestone |
+|---|----------|-------|-----------|
+| {number} | {PREFIX}-{number} | {title} | {milestone or "Standalone"} |
+
+**Next steps:**
+- Run `refine-story-v4 #{number}` to add technical detail
+- Or add to the next `orchestrate-v4` batch
+```
+
+---
+<!-- skill-version: 5.0 -->
+<!-- last-updated: 2026-06-27 -->
+<!-- pipeline: v5 -->
+<!-- pipeline: v4 -->

--- a/skills/add-story-v5/SKILL.md
+++ b/skills/add-story-v5/SKILL.md
@@ -59,7 +59,7 @@ REPO_NAME=$(echo "$REPO_NWO" | cut -d/ -f2)
 
 ### 0d. Resolve Project Board IDs
 
-Query GraphQL for project ID, field ID, and status option IDs (same pattern as orchestrate-v4 Step 0c).
+Query GraphQL for project ID, field ID, and status option IDs (same pattern as orchestrate-v5 Step 0c).
 
 ---
 
@@ -252,8 +252,8 @@ Tell the user what was created:
 | {number} | {PREFIX}-{number} | {title} | {milestone or "Standalone"} |
 
 **Next steps:**
-- Run `refine-story-v4 #{number}` to add technical detail
-- Or add to the next `orchestrate-v4` batch
+- Run `refine-story-v5 #{number}` to add technical detail
+- Or add to the next `orchestrate-v5` batch
 ```
 
 ---

--- a/skills/conformance-v5/SKILL.md
+++ b/skills/conformance-v5/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: conformance-v5
+description: "Audit a project against TI Engineering Standards, including the v5 four-tier test model (TR-1..TR-11) and the v5 CI tiering. Informational only — produces a gap report, creates no files and makes no changes. Use when onboarding an existing codebase, returning to a dormant project, or after standards have been updated."
+argument-hint: "[full | pipeline | standards] (default: full)"
+---
+
+You are auditing a project against TI Engineering Standards. Your job is to read the project and produce an honest gap report. You make **no changes** — no file edits, no commits, no tickets, no PRs. Your only output is the report.
+
+**Audit under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Every finding must be **grounded in the actual file** (ED-1) — cite the `file:line` you read, never report a gap from an assumption about how the project "probably" looks. A check you genuinely cannot determine is reported as **Unknown with the reason** (ED-3), never silently passed or failed. This honest-evidence discipline *is* the value of a conformance report.
+
+## Mode
+
+When `$ARGUMENTS` contains a mode, use it:
+- `full` — audit everything: pipeline/environments, code standards, testing, project structure (default)
+- `pipeline` — audit only pipeline and environments conformance (faster, focused on `standards/environments.md`)
+- `standards` — audit only code and testing standards (architecture, naming, testing patterns, etc.)
+
+If no mode is provided, default to `full`.
+
+## Step 0: Load Context
+
+1. Sync and read the standards repo:
+   - If `../TI-Engineering-Standards/` exists: `cd ../TI-Engineering-Standards && git pull --ff-only && cd -`
+   - If not: `git clone https://github.com/drdatarulz/TI-Engineering-Standards.git ../TI-Engineering-Standards/`
+2. Read `../TI-Engineering-Standards/CLAUDE.md` and **every standards file it references**
+3. Read `CLAUDE.md` — project-specific rules and declared exceptions
+4. Read `ARCHITECTURE.md` — system design context
+
+---
+
+## Step 1: Understand the Project
+
+Before auditing, build a picture of what the project is:
+
+```bash
+# Repo identity
+gh repo view --json name,description,defaultBranch
+
+# Solution structure
+find . -name "*.sln" -o -name "*.csproj" | grep -v bin | grep -v obj | head -30
+
+# Test projects
+find . -path "*/tests/*" -name "*.csproj" | grep -v bin | grep -v obj
+
+# CI/CD files
+ls -la .github/workflows/
+
+# Infrastructure files
+find . -name "*.bicep" -o -name "*.bicepparam" | grep -v bin | grep -v obj
+
+# Git hooks
+ls -la .githooks/ 2>/dev/null || echo "No .githooks directory"
+```
+
+Read each workflow YAML file in full. Read each Bicep file. Read the solution structure.
+
+---
+
+## Step 2: Pipeline & Environments Audit
+
+*(Skip if mode is `standards`)*
+
+Work through each item in the `standards/environments.md` conformance checklist. For each item, determine pass, fail, or not-applicable with a brief finding.
+
+### 2a. Infrastructure
+
+For each check, look at the actual files:
+
+```bash
+# Check Bicep structure
+find . -name "*.bicep" -o -name "*.bicepparam" | grep -v bin
+
+# Check environment parameter
+grep -n "param environment" infra/main.bicep 2>/dev/null || echo "Not found"
+```
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| `infra/main.bicep` exists | | |
+| Accepts `environment` parameter | | |
+| Parameter files for dev/staging/prod | | |
+| Resource names derived from environment | | |
+
+### 2b. Application
+
+```bash
+# Health endpoint
+grep -rn "MapHealthChecks\|/health" src/ --include="*.cs"
+
+# Auth bypass
+grep -rn "UseDevBypass\|DevBypass" src/ --include="*.cs"
+grep -rn "UseDevBypass" --include="*.json" .
+```
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| `/health` endpoint implemented | | |
+| Auth bypass controlled by `Authentication:UseDevBypass` | | |
+| Auth bypass absent from prod config | | |
+
+### 2c. GitHub Environments
+
+```bash
+# Check GitHub Environments are configured
+gh api repos/{REPO_OWNER}/{REPO_NAME}/environments --jq '.environments[].name' 2>/dev/null
+
+# Check environment protection rules
+gh api repos/{REPO_OWNER}/{REPO_NAME}/environments/staging --jq '.protection_rules' 2>/dev/null
+gh api repos/{REPO_OWNER}/{REPO_NAME}/environments/production --jq '.protection_rules' 2>/dev/null
+```
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| `dev` environment configured | | |
+| `staging` environment configured | | |
+| `production` environment configured | | |
+| `staging` has required reviewers | | |
+| `production` has required reviewers | | |
+
+### 2d. Pipeline
+
+Read each workflow YAML file in full. v5 splits tests into **three workflows** (see `templates/workflows/` and `standards/testing.md` → CI/CD Testing Tiers):
+
+```bash
+ls .github/workflows/
+cat .github/workflows/fast-tests.yml 2>/dev/null
+cat .github/workflows/integration-tests.yml 2>/dev/null
+cat .github/workflows/ui-tests.yml 2>/dev/null
+cat .github/workflows/deploy.yml 2>/dev/null
+```
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| `fast-tests` workflow runs on every PR (Unit `Domain.Tests`+`Infrastructure.Tests` and Contract `Api.Tests`) | | |
+| `fast-tests` runs with **no Docker daemon** — fast tier is Docker-free (TR-11) | | |
+| `integration-tests` workflow runs on every PR (real infra via Testcontainers) | | |
+| `ui-tests` runs via **`workflow_dispatch`** on the self-hosted runner — NOT a per-PR gate | | |
+| Merge gate = `fast-tests` + `integration-tests` green (enforced by orchestrator, not branch protection) | | |
+| Deploy triggers on merge to main, targets `dev` GitHub Environment | | |
+| Post-deploy smoke step exists | | |
+| Staging job targets `staging`; includes smoke + UI gates | | |
+| Production job targets `production` GitHub Environment | | |
+| Images built once and retagged — not rebuilt | | |
+
+---
+
+## Step 3: Code & Standards Audit
+
+*(Skip if mode is `pipeline`)*
+
+This is a sampling audit, not an exhaustive line-by-line review. Read a representative set of files from each layer and assess conformance. Flag patterns, not individual instances — if a violation appears once it may be an oversight; if it appears across multiple files it's a pattern worth calling out.
+
+### 3a. Project Structure
+
+```bash
+# Verify expected project layout
+find src -maxdepth 2 -type d | grep -v bin | grep -v obj
+find tests -maxdepth 2 -type d | grep -v bin | grep -v obj
+```
+
+Check against `standards/architecture.md`:
+- Domain project has zero dependencies (no NuGet, no project references)
+- Interfaces in `Domain/Interfaces/`, models in `Domain/Models/`
+- Infrastructure types absent from interfaces
+- Fakes project exists: `{Project}.Fakes`
+
+### 3a.1 Service Data Access — API as the Boundary
+
+For every project that is a **worker, CRON job, or background service** (NOT the API, NOT the Migrator), check whether it accesses data through the API or directly through infrastructure:
+
+```bash
+# Find worker/service projects (exclude Api, Migrator, Domain, Infrastructure, Web, test projects)
+find src -maxdepth 1 -type d | grep -v -E 'Api|Migrator|Domain|Infrastructure|Web|obj|bin' | while read dir; do
+  if [ -f "$dir/Program.cs" ]; then
+    echo "=== $(basename $dir) ==="
+    # Check for direct infrastructure registrations
+    grep -n "ISubmissionRepository\|IBlobStorageService\|ITeamMailboxConfigRepository\|I.*Repository\|IAuditWriter\|ISubmissionAuditWriter" "$dir/Program.cs" 2>/dev/null | head -10
+    # Check for HttpClient-based API access (the correct pattern)
+    grep -n "HttpClient\|AddHttpClient\|IApiClient" "$dir/Program.cs" 2>/dev/null | head -5
+  fi
+done
+```
+
+Per `standards/architecture.md` → "Service Data Access — API as the Boundary":
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| Workers access data through API endpoints (not direct DB/storage) | | |
+| No direct `I*Repository` registrations in worker DI | | |
+| No direct `IBlobStorageService` registrations in worker DI | | |
+| Workers use `HttpClient` to call API endpoints | | |
+| Any exceptions are documented and approved by project owner | | |
+
+If a worker has direct infrastructure access, flag it as a gap. Note the standard's guidance: "do not partially convert — leave as-is until a dedicated conversion ticket is created."
+
+### 3b. API Layer
+
+Read 3–5 endpoint files. Check against `standards/api-design.md` and `standards/dotnet.md`:
+- Minimal APIs (no MVC controllers)
+- Typed DTOs — no anonymous types returned
+- `[JsonPropertyName]` on all DTO properties
+- `.Produces<T>()` declarations on endpoints
+- No hard-coded config fallbacks (`?? "default"` patterns)
+
+### 3c. Data Access
+
+Read 2–3 repository files. Check against `standards/database.md` and `standards/dotnet.md`:
+- Dapper only (no Entity Framework)
+- INT IDENTITY primary keys (no GUIDs)
+- No raw string concatenation in SQL
+- DbUp migrations — forward-only, no down migrations
+
+### 3d. Testing — the v5 four-tier model (TR-1..TR-11)
+
+Audit against `standards/testing.md` → Test Tiers + Test Rules. This is the heart of the v5 conformance check: the right **shape** (a pyramid, not an inverted one), not just "tests exist."
+
+```bash
+# Tier projects — expect FOUR test-project kinds, by where each tier lives
+find tests -name "*.csproj" | grep -v bin
+#   Unit:        {Project}.Domain.Tests  AND  {Project}.Infrastructure.Tests
+#   Contract:    {Project}.Api.Tests   (WebApplicationFactory over fakes, no Docker)
+#   Integration: real-infra project (Testcontainers)
+#   UI:          Playwright project
+
+# Contract tier uses the real host (WebApplicationFactory)
+grep -rln "WebApplicationFactory" tests/ --include="*.cs"
+
+# Critical-path journeys — count the repo-wide tagged set (TR-6 ceiling 10, floor ~3)
+grep -rn 'Trait("CriticalPath"' tests/ --include="*.cs" | wc -l
+
+# Docker/Testcontainers in the fast tier? (TR-11 — must be NONE in Domain/Infra/Api .Tests)
+grep -rln "Testcontainers\|DockerClient\|new .*Container" tests/*Domain.Tests tests/*Infrastructure.Tests tests/*Api.Tests 2>/dev/null
+
+# Silent failures / Skip (TR-8) and UI anti-patterns (TR-9)
+grep -rn "Skip\s*=" tests/ --include="*.cs" | head
+grep -rn "Task.Delay\|Thread.Sleep\|WaitForTimeoutAsync" tests/ --include="*.cs" | head
+
+# Hygiene (unchanged): no mocking frameworks, Shouldly not FluentAssertions
+grep -rn "Moq\|NSubstitute\|FakeItEasy" tests/ --include="*.cs" | head
+grep -rn "FluentAssertions\|\.Should()" tests/ --include="*.cs" | head
+```
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| Unit tier spans **two** projects: `Domain.Tests` AND `Infrastructure.Tests` | | |
+| Contract tier (`Api.Tests`) exists and uses `WebApplicationFactory` over fakes | | |
+| **No business logic in Contract** — Contract tests assert wiring/seam, not business outcomes (TR-2) | | |
+| **No inverted pyramid** — logic tested at Unit, not at Integration; no behavior tested at two tiers (TR-1/TR-10) | | |
+| Integration tests assert only real-infra behavior, not re-asserted contract (TR-3) | | |
+| Critical-path count **≤ 10 repo-wide** (TR-6 ceiling); floor ~3 if any UI surface | | |
+| No `Skip`, no silent/guard-and-bail tests (TR-8) | | |
+| UI uses Page Object Model + condition-based waits — no `Task.Delay`/`Thread.Sleep`/inline locators (TR-9) | | |
+| **No Testcontainers/Docker in the fast tier** projects (TR-11) | | |
+| No mocking frameworks; Shouldly (not FluentAssertions); `Snake_case` test names | | |
+
+**Inverted-pyramid is the headline finding.** If logic-only scenarios (pricing, mapping, validation walks) live in the Integration project, or `Infrastructure.Tests` is missing so Infrastructure logic has nowhere fast to land, call it out as a pattern — it is the single largest driver of slow, flaky suites.
+
+### 3e. Error Handling & Logging
+
+Read Program.cs and 1–2 service files. Check against `standards/error-handling.md` and `standards/logging.md`:
+- Serilog configured
+- No swallowed exceptions (`catch {}` or `catch (Exception) {}` with no logging)
+- Structured logging (no string interpolation in log messages)
+
+### 3f. Security
+
+```bash
+# Check for hardcoded secrets
+grep -rn "password\s*=\s*\"" src/ --include="*.cs" -i | head -5
+grep -rn "secret\s*=\s*\"" src/ --include="*.cs" -i | head -5
+```
+
+Check against `standards/security.md`:
+- No secrets in source code
+- Auth configured (not commented out)
+- CORS configured appropriately
+
+### 3g. Git Hygiene
+
+```bash
+# Check git hooks
+cat .githooks/commit-msg 2>/dev/null || echo "No commit-msg hook"
+
+# Check for Co-Authored-By in recent commits
+git log --oneline -20 | head -20
+git log --format="%B" -20 | grep -i "co-authored" | head -5
+```
+
+### 3h. v5 Adoption
+
+```bash
+# Orchestration entrypoint vendored
+ls scripts/orchestrate.sh 2>/dev/null || echo "No vendored orchestrate.sh"
+# v5 skills synced locally
+ls .claude/skills/ 2>/dev/null | grep -E 'v5' | head
+# Standards sync includes the discipline standard
+ls ../TI-Engineering-Standards/standards/engineering-discipline.md 2>/dev/null
+```
+
+| Check | Result | Finding |
+|-------|--------|---------|
+| `scripts/orchestrate.sh` wrapper vendored (for long-haul runs) | | |
+| v5 pipeline skills present in `.claude/skills/` (not stale v4-only) | | |
+| `standards/engineering-discipline.md` present in the synced standards | | |
+
+---
+
+## Step 4: Produce Report
+
+```
+## Conformance Report
+**Project:** {project name}
+**Date:** {today}
+**Mode:** full | pipeline | standards
+**Audited by:** conformance-v5
+
+---
+
+### Summary
+
+| Category | Passed | Failed | N/A |
+|----------|--------|--------|-----|
+| Infrastructure (Bicep) | X | X | X |
+| Application | X | X | X |
+| GitHub Environments | X | X | X |
+| Pipeline | X | X | X |
+| Project Structure | X | X | X |
+| API Layer | X | X | X |
+| Data Access | X | X | X |
+| Testing | X | X | X |
+| Error Handling & Logging | X | X | X |
+| Security | X | X | X |
+| Git Hygiene | X | X | X |
+| **Total** | **X** | **X** | **X** |
+
+**Overall assessment:** Conformant | Mostly conformant | Significant gaps | Non-conformant
+
+> Report each check as Pass / Fail / N-A / **Unknown** (with the reason it couldn't be determined — ED-3). Every Fail cites the `file:line` evidence behind it (ED-1).
+
+---
+
+### Gaps Found
+
+List every failed check with context:
+
+#### [Category]: [Check description]
+**Finding:** What was found (or not found)
+**Standard:** `standards/{file}.md` — relevant rule
+**Suggested fix:** What would need to change to pass this check
+
+---
+
+### Passed Checks
+
+[Collapsed list of everything that passed — one line each]
+
+---
+
+### Declared Exceptions
+
+[Any items marked as exceptions in the project's CLAUDE.md, e.g. personal project with direct-to-prod deploys]
+
+---
+
+### Notes
+
+[Anything observed that doesn't map cleanly to a specific check but is worth flagging — patterns, drift, areas of concern]
+```
+
+---
+<!-- skill-version: 5.0 -->
+<!-- last-updated: 2026-06-27 -->
+<!-- pipeline: v5 -->

--- a/skills/engineering-review-v5/SKILL.md
+++ b/skills/engineering-review-v5/SKILL.md
@@ -74,6 +74,8 @@ For each file changed in the PR, read the complete file (not just the diff) to u
 
 ## Step 2: Run Checklist
 
+**Review under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). The reviewer is the *adversarial* half of the discipline: do not trust the PR's prose or the spec's asserted data flows — **re-trace them to source (ED-1)** and try to prove them wrong (ED-2). A "checked" criterion or an asserted data flow with no backing source is flagged, not trusted (ED-3). Two checks below are ED applied: the Acceptance Criteria Integrity check (ED-1/ED-3) and the Ungrounded Claim / Data-Flow check (ED-1). Watch for hidden scope-forks (ED-4). Cite the ED rules by ID; do not restate them.
+
 ### v5 Test Enforcement (tiers + TR rules)
 
 This is the heart of v5 review: keep each behavior at its cheapest sufficient tier and the TR rules honest. Run the rows scoped to `{MODE}` (see the grid in Step 2.5), **plus TR-10 on every mode**. Cite `standards/testing.md` → Test Tiers / Test Rules. Each is **[JUDGMENT]** unless noted [CI].
@@ -200,9 +202,27 @@ that calls the API's endpoints. If direct access is genuinely warranted,
 get explicit approval from the project owner and document the exception.
 ```
 
+### Ungrounded Claim / Data-Flow Check (Implementation Mode, ED-1)
+
+The PR description and the linked spec assert how data moves — "captures X from the Y response", "the handler receives Z", "this effect re-fires on W". These are the claims most likely to be **plausible but never traced to source**, and they pass review silently because they *read* correctly.
+
+For each asserted data flow / payload shape / return type the PR relies on, **confirm it against the actual definition** (the DTO/type, the endpoint, the effect's dependency list) — don't accept the prose. The specific failure to catch: a spec asserts a field arrives on a payload that never carries it (e.g. "captured from the POST response" when the field only exists on a different GET response). If the implementation is built on an ungrounded claim, the feature is quietly broken even though every test the implementer wrote passes.
+
+**If an asserted data flow doesn't match the source:** blocking violation.
+
+```
+**[Standards Violation: Ungrounded Claim]**
+The PR/spec asserts "{claim}" but the source shows otherwise: `{type/endpoint}`
+(`{file}:{line}`) does not carry `{field}` / is keyed on `{actual}`. The behavior
+this relies on cannot work as written.
+
+**Standard:** `standards/engineering-discipline.md` — ED-1 (grounded claims)
+**Fix:** Re-trace the data flow to source and correct the approach (or the spec).
+```
+
 ### Scope Deferral & Acceptance Criteria Integrity Check (Implementation Mode Only)
 
-After reviewing the code, perform TWO checks:
+After reviewing the code, perform TWO checks. (Check 1 is ED-1/ED-3 applied: a checked criterion is a *claim* of completed work — it must be grounded in code, never trusted on assertion.)
 
 #### Check 1: Acceptance criteria vs. code (HARD GATE)
 
@@ -419,6 +439,6 @@ DETAILS:
 A FAIL on any [JUDGMENT] TR row means STATUS must be `ChangesRequested`, routed back to the owning skill.
 
 ---
-<!-- skill-version: 5.0 -->
-<!-- last-updated: 2026-06-22 -->
+<!-- skill-version: 5.1 -->
+<!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->

--- a/skills/implement-ticket-v5/SKILL.md
+++ b/skills/implement-ticket-v5/SKILL.md
@@ -63,6 +63,8 @@ Do NOT write any code until all three steps are complete.
 
 All rules from the 12 standards files apply — you loaded them in the Context Loading step above. The most commonly violated rules involve: Domain zero-dependency, Dapper-only, no mocking frameworks, hand-rolled fakes, no Co-Authored-By. When in doubt, re-check the standards files.
 
+**Implement under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Do not code against an assumed data flow or contract — when your implementation depends on what a payload contains, what an endpoint returns, or how an interface behaves, **confirm it in the source first (ED-1)**, don't trust the spec's prose or a plausible mental model. Before you finalize the PR you run an **adversarial self-review (ED-2)** — see step 4.5. Cite the ED rules by ID; do not restate them.
+
 ## Scope Deferral Rules (Non-Negotiable)
 
 - **NEVER check off an acceptance criterion that you did not implement.** A checked checkbox means the code exists in this PR. If you cannot implement a criterion, leave it unchecked.
@@ -142,6 +144,14 @@ Use the build and test commands from the project's `CLAUDE.md`:
 - Every test must reach a real assertion — no silent passes, no `Skip`, no asserting buggy behavior (TR-8).
 - Confirm the full solution builds with no errors
 
+### 4.5. ADVERSARIAL SELF-REVIEW (ED-2) — before committing
+
+Treat the diff you just wrote as a suspect, not a finished product. Try to prove it wrong before the reviewer does:
+
+- **Re-trace each assumption to source (ED-1).** For every data flow / payload shape / return type / contract your code relies on, confirm it against the actual definition (`file:line`) — especially the ones that *felt* obviously right. A spec can assert a data flow the payload type never carried; do not inherit that error into the implementation.
+- **Acceptance-criteria integrity.** For every criterion you are about to check off, confirm the backing code actually exists in this diff. A checked box with no code is a phantom (ED-3) — leave it unchecked and report Partial.
+- **Scope-fork check (ED-4).** If your approach turned out to change blast radius or which test tiers apply (e.g., a "frontend-only" ticket that now needs an API/Contract change), surface it in the PR body and issue comment — don't hide it.
+
 ### 5. COMMIT & PUSH
 - Stage specific files by name (never `git add .`)
 - Commit message format: `{STORY_ID}: Concise description of why this change was made`
@@ -208,6 +218,8 @@ gh issue comment {ISSUE_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} --body "$(cat <<
 
 **Key decisions:**
 - [List decisions made during implementation]
+
+**Discipline self-check (ED):** Assumptions traced to source (ED-1); adversarial self-review run (ED-2); every checked criterion has backing code in the diff (no phantoms, ED-3); scope-forks surfaced (ED-4). See `standards/engineering-discipline.md`.
 
 **Status:** Ready for engineering review
 EOF
@@ -340,6 +352,6 @@ When invoked with `{FIX_MODE}=true`, you are addressing review feedback on an ex
    ```
 
 ---
-<!-- skill-version: 5.0 -->
-<!-- last-updated: 2026-06-22 -->
+<!-- skill-version: 5.1 -->
+<!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->

--- a/skills/orchestrate-v5/SKILL.md
+++ b/skills/orchestrate-v5/SKILL.md
@@ -27,7 +27,7 @@ This is the per-ticket pipeline WORKING mode runs for each of the up-to-N ticket
 3.   REVIEW (implementation) ─ engineering-review-v5 mode=implementation (tiers + TR grid + build + fast tests)
      └─ Loop: reviewer ↔ implementer (max 3 iterations)
      └─ On approve → continue to 3.5
-3.5. SECURITY REVIEW ──────── security-review-v4 (OWASP Top 10 + infrastructure)
+3.5. SECURITY REVIEW ──────── security-review-v5 (OWASP Top 10 + infrastructure)
      └─ Loop: reviewer ↔ implementer (max 2 iterations)
      └─ On pass → merge PR #1 (fast + integration gates must be green)
 4.   INTEGRATION TESTS ────── integration-test-v5 (real-infra only; creates PR #2)
@@ -529,9 +529,9 @@ Pass to Agent tool with `subagent_type: "general-purpose"`.
 
 Run an OWASP Top 10 security analysis on the approved implementation PR. If the PR contains infrastructure files (`.bicep`, `Dockerfile`, `.github/workflows/*.yml`), the infrastructure security checklist runs automatically. Max 2 iterations (security issues that persist after one fix likely need human judgment).
 
-#### 3.5a. Spawn security-review-v4
+#### 3.5a. Spawn security-review-v5
 
-Read `.claude/skills/security-review-v4/SKILL.md` and substitute:
+Read `.claude/skills/security-review-v5/SKILL.md` and substitute:
 - `{PR_NUMBER}` → the implementation PR number
 - `{ISSUE_NUMBER}` → the GitHub issue number
 - `{STORY_ID}` → the story ID
@@ -544,7 +544,7 @@ Pass to Agent tool with `subagent_type: "general-purpose"`.
 
 #### 3.5b. Process security review result
 
-**Post a dedicated issue comment for every security review result** — this creates a real-time audit trail on the issue. (The security-review-v4 skill posts its own audit comment; verify it was posted but do not duplicate it.)
+**Post a dedicated issue comment for every security review result** — this creates a real-time audit trail on the issue. (The security-review-v5 skill posts its own audit comment; verify it was posted but do not duplicate it.)
 
 **If `STATUS: Passed`:**
 - Merge the PR:
@@ -857,7 +857,7 @@ Pass to Agent tool with `subagent_type: "general-purpose"`.
   Omit the CI/CD Health table if all watchers reported `Passed` (i.e., nothing interesting happened).
   Use the per-ticket metrics tracked in `session_metrics.tickets[]` for this ticket. Tokens should be formatted with comma separators (e.g., `45,230`). Duration should be in human-readable format (e.g., `1m 35s`). Omit rows for phases that were skipped (e.g., if no integration tests were run, omit that row).
 
-  **Capturing the model per phase.** Every per-stage subagent skill (`refine-story-v5`, `implement-ticket-v5`, `engineering-review-v5`, `security-review-v4`, `integration-test-v5`, `ui-test-v5`) reports its model in the `MODEL:` line of its STATUS block. Extract that value verbatim and use it in the table above. Use the friendly name (e.g., `Opus 4.7`, `Sonnet 4.6`, `Haiku 4.5`) rather than the model ID. When a phase runs multiple iterations on different models (rare, but possible if you override per iteration), list them comma-separated (e.g., `Opus 4.7, Sonnet 4.6`).
+  **Capturing the model per phase.** Every per-stage subagent skill (`refine-story-v5`, `implement-ticket-v5`, `engineering-review-v5`, `security-review-v5`, `integration-test-v5`, `ui-test-v5`) reports its model in the `MODEL:` line of its STATUS block. Extract that value verbatim and use it in the table above. Use the friendly name (e.g., `Opus 4.7`, `Sonnet 4.6`, `Haiku 4.5`) rather than the model ID. When a phase runs multiple iterations on different models (rare, but possible if you override per iteration), list them comma-separated (e.g., `Opus 4.7, Sonnet 4.6`).
 
   **Capturing the orchestrator's own model.** Report the model the orchestrator (this session) is running on — read it from the system prompt's "You are powered by the model named …" line. Use the same friendly-name format.
 

--- a/skills/prd-to-backlog-v5/SKILL.md
+++ b/skills/prd-to-backlog-v5/SKILL.md
@@ -325,8 +325,8 @@ For each milestone, for each story in that milestone:
 
 ### Next Steps
 1. Review the created issues on the project board
-2. Run `refine-story-v4` on each story to add technical detail
-3. Use `orchestrate-v4` to begin implementation
+2. Run `refine-story-v5` on each story to add technical detail
+3. Use `orchestrate-v5` to begin implementation
 ```
 
 ---

--- a/skills/prd-to-backlog-v5/SKILL.md
+++ b/skills/prd-to-backlog-v5/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: prd-to-backlog-v5
+description: "Decompose a PRD, Screen Inventory, and Decisions Log into a milestoned backlog of vertical-slice stories. Nominates the repo-wide critical-path journeys, surfaces a three-part contribution, and creates GitHub issues on the project board following TI story-writing standards."
+argument-hint: "[path to PRD] [optional: --screen-inventory path] [optional: --decisions-log path]"
+---
+
+# PRD to Backlog
+
+You are converting a PRD into a development backlog. You produce well-structured, right-sized stories with milestones following TI story-writing standards. You create GitHub issues and organize them on the project board.
+
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Ground decomposition claims about existing code in the source (ED-1); adversarially re-check the backlog and **surface your own take** before creating issues (ED-2, Phase 2.5). The backlog is also the natural place to **budget the repo-wide critical-path journeys** (TR-6 ceiling is 10 across the whole repo) — nominate them once here (Phase 1f) so refine/ui-test draw from a budgeted pool instead of each story minting its own. Cite ED/TR rules by ID; do not restate them.
+
+You do NOT implement anything. You produce stories.
+
+## Phase 0: Load Context
+
+### 0a. Resolve Project Identity
+
+```bash
+REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+REPO_OWNER=$(echo "$REPO_NWO" | cut -d/ -f1)
+REPO_NAME=$(echo "$REPO_NWO" | cut -d/ -f2)
+```
+
+### 0b. Sync Standards & Read Config
+
+1. Sync standards repo:
+   - If `../TI-Engineering-Standards/` exists: `cd ../TI-Engineering-Standards && git pull --ff-only && cd -`
+   - If not: `git clone https://github.com/drdatarulz/TI-Engineering-Standards.git ../TI-Engineering-Standards/`
+2. Read `../TI-Engineering-Standards/CLAUDE.md`
+3. **Read `../TI-Engineering-Standards/standards/story-writing-standards.md` in full** — this defines how stories must be written, sized, and ordered. Follow it exactly.
+4. Read `../TI-Engineering-Standards/standards/project-tracking.md` — board structure, labels, custom fields
+5. Read `CLAUDE.md` — extract: story ID prefix, project board URL, build commands
+6. Read `ARCHITECTURE.md` — system design, component boundaries, database schema
+
+### 0c. Read Input Documents
+
+Parse `$ARGUMENTS` for file paths:
+
+1. **PRD** (required) — the primary input
+2. **Screen Inventory** (optional) — if `--screen-inventory` provided or if a screen inventory file exists in `docs/`
+3. **Decisions Log** (optional) — if `--decisions-log` provided or if a decisions log file exists in `docs/`
+
+If the PRD path is not provided, ask the user.
+
+### 0d. Resolve Project Board IDs
+
+Extract the project number from the board URL in CLAUDE.md, then query for project ID, field ID, and status option IDs:
+
+```bash
+gh api graphql -f query='
+{
+  user(login: "REPO_OWNER") {
+    projectV2(number: PROJECT_NUMBER) {
+      id
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}'
+```
+
+Store the project ID, field ID, and option IDs for: Inbox, Up Next, In Progress, Done, Waiting/Blocked.
+
+---
+
+## Phase 1: Analyze and Decompose
+
+### 1a. Identify Components and Boundaries
+
+From the PRD and ARCHITECTURE.md, identify:
+
+- Compilable components (APIs, clients, workers, background services)
+- Database entities and their relationships
+- External integrations and third-party dependencies
+- Authentication and authorization boundaries
+
+### 1b. Identify Screens and User Flows
+
+From the Screen Inventory (or PRD if no inventory exists):
+
+- Every screen/view the user interacts with
+- Navigation paths between screens
+- Modals and overlays
+- Shared UI components that appear on multiple screens
+
+### 1c. Determine Foundation Work
+
+Identify what genuinely cannot be part of a vertical slice:
+
+- Solution/project scaffolding
+- Shared middleware (auth, logging, error handling)
+- Database project setup and initial seed migration
+- Docker/test environment configuration
+- CI/CD pipeline setup
+
+Keep this list as short as possible. If a database table is only used by one feature, it belongs in that feature's story, not here.
+
+### 1d. Define Milestones
+
+Group screens and capabilities into milestones per story-writing standards:
+
+- **Milestone 1:** Minimum viable visibility — login + primary landing screen. Target: "I can log in and see something."
+- **Milestone 2:** Core entity lifecycle — the primary thing the application manages.
+- **Milestone 3+:** Secondary features, grouped by relatedness.
+
+Each milestone should map to a coherent set of screens from the screen inventory.
+
+### 1e. Decompose Into Stories
+
+For each milestone, create vertical-slice stories per story-writing standards:
+
+- Group by entity lifecycle (create + list + view + delete = one story)
+- Split along capability boundaries, not CRUD operations
+- Each story should be completable by a single developer agent session
+- Order stories within a milestone so each builds on the previous logically
+
+### 1f. Nominate the Critical-Path Journeys (repo-wide budget)
+
+The UI critical-path set is capped at **10 journeys repo-wide** (TR-6 ceiling; floor ~3) — a hard, repo-level budget, not a per-story one. The backlog is the only vantage point that sees the whole repo at once, so nominate the candidate set here:
+
+- Identify the journeys that genuinely carry the product: **auth**, the **core create→read** flow for the primary entity, the **money path** (payment/checkout/submit), and the few other end-to-end flows whose failure is unacceptable.
+- Keep the list to **≤10**, ideally 3–6. Note which story will own each.
+- These are *nominations*: `refine-story-v5` declares the journey on the owning story (TR-6) and `ui-test-v5` tags it; `engineering-review-v5` enforces the ≤10 count. Recording the budget here keeps the repo from drifting past the ceiling one story at a time.
+
+---
+
+## Phase 2: Present Plan for Review
+
+**Do NOT create any GitHub issues yet.** Present the full backlog plan to the user first:
+
+```markdown
+## Backlog Plan
+
+### Foundation ({N} stories)
+1. [title] — [one-line description]
+2. [title] — [one-line description]
+
+### Milestone 1: [Name] ({N} stories)
+3. [title] — [one-line description]
+4. [title] — [one-line description]
+→ MILESTONE: [Name] — [What can be reviewed at this point]
+
+### Milestone 2: [Name] ({N} stories)
+5. [title] — [one-line description]
+...
+→ MILESTONE: [Name] — [What can be reviewed]
+
+**Totals:** {N} stories + {N} foundation + {N} milestones = {N} issues
+
+### Critical-path journeys (≤10 repo-wide — TR-6)
+1. {journey} — owned by story [N]
+2. {journey} — owned by story [N]
+...
+```
+
+Ask the user: **"Does this decomposition look right? Should I adjust any story scope, reorder anything, or add/remove milestones before I create the issues?"**
+
+Wait for approval. If the user requests changes, adjust and re-present.
+
+---
+
+## Phase 2.5: Adversarial Self-Review & Contribution
+
+Before creating issues, cross-examine the backlog, then volunteer your take.
+
+**Adversarial self-review (ED-2).** Re-check claims about the existing codebase against the source (ED-1) — foundation work that may already exist, entities/screens assumed present. Is the critical-path list within the ≤10 ceiling and genuinely the highest-value flows (ED-4 — an over-budget set is a scope fork)? Anything unconfirmed is flagged, not assumed (ED-3).
+
+**Surface your own take (the three-part contribution).** Volunteer this without being asked:
+
+- **What we missed** — capabilities/screens/flows implied by the PRD but absent from the decomposition; foundation work not called out
+- **What we should consider** — alternative milestone boundaries, story splits/merges, sequencing risks, the critical-path nominations
+- **What I'd add** — stories, dependencies, or watch-outs that strengthen the backlog
+- **What I considered and set aside** — decompositions weighed and rejected, with why
+
+---
+
+## Phase 3: Create GitHub Issues
+
+Only proceed after user approves the plan.
+
+### 3a. Create Foundation Issues
+
+For each foundation story:
+
+```bash
+ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
+  --title "{Title}" \
+  --label "foundation" \
+  --body "{issue body per story template}")
+ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --title "{PREFIX}-${ISSUE_NUM}: {Title}"
+```
+
+After creation, set custom fields (Type=Task, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`) and move to **Up Next**.
+
+### 3b. Create Story Issues (Per Milestone)
+
+For each vertical-slice story:
+
+```bash
+ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
+  --title "{Title}" \
+  --label "story" \
+  --body "$(cat <<'EOF'
+## Summary
+
+{Description — framed from user's perspective}
+
+**Milestone:** {Milestone Name}
+
+## Acceptance Criteria
+
+- [ ] {Criterion 1 — specific and testable}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+## Branch
+
+`story/{PREFIX}-{ISSUE_NUM}-short-name`
+
+## Test Coverage (intent — refine assigns tiers)
+
+Coarse intent only; `refine-story-v5` produces the enforced behavior-first tier table (one behavior, one tier — TR-1) and declares any critical-path journey (TR-6) from the backlog's nominated set. Do not pre-assign tiers here. See `standards/testing.md`.
+
+- **Likely tiers:** {e.g. Unit + Contract; Integration only if real-infra behavior; UI only if a user journey}
+- **Critical path?** {Yes — names a journey from the repo-wide critical-path set | No}
+
+## Plan
+
+_Fill in before starting implementation._
+
+## Implementation Notes
+
+_Fill in during implementation._
+
+## Test Results
+
+_Fill in when done._
+
+## Files Changed
+
+_Fill in when done._
+EOF
+)"
+```
+
+After creation, extract the issue number from the URL, update the title to `{PREFIX}-{ISSUE_NUM}: {Title}`, and set custom fields (Type=Story, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`). Move to **Up Next**.
+
+### 3c. Create Milestone Marker Issues
+
+At the end of each milestone group:
+
+```bash
+gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
+  --title "MILESTONE: {Milestone Name}" \
+  --label "milestone" \
+  --body "$(cat <<'EOF'
+## Review Checklist
+- [ ] Application starts without errors
+- [ ] {Screen/flow 1} is functional: {what to verify}
+- [ ] {Screen/flow 2} is functional: {what to verify}
+- [ ] No regressions in previously completed milestones
+
+## Smoke Test
+- [ ] Application process starts successfully
+- [ ] GET /health returns 200
+- [ ] {Key endpoint} returns expected response
+- [ ] UI loads at localhost:{port} without console errors
+
+## Stories in This Milestone
+- #{issue_number}: {title}
+- #{issue_number}: {title}
+EOF
+)"
+```
+
+After creation, set custom fields. Move to **Up Next**.
+
+**Ensure the `milestone` label exists** before creating milestone markers — if not, create it:
+```bash
+gh label create milestone --repo {REPO_OWNER}/{REPO_NAME} --description "Milestone marker issue (review gate)" --color "0E8A16"
+```
+
+### 3d. Link Stories as Sub-Issues of Milestones
+
+After creating all stories and milestone markers, link each story as a sub-issue of its milestone marker. This gives epic-style progress tracking — GitHub displays "N of M complete" on each milestone as stories are closed.
+
+For each milestone, for each story in that milestone:
+
+1. Get the story's database ID:
+   ```bash
+   gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
+     repository(owner: $owner, name: $repo) { issue(number: $number) { databaseId } }
+   }' -f owner={REPO_OWNER} -f repo={REPO_NAME} -F number={STORY_ISSUE_NUMBER} --jq '.data.repository.issue.databaseId'
+   ```
+2. Add as sub-issue using the GitHub MCP `sub_issue_write` tool:
+   - `method`: `add`
+   - `owner`: `{REPO_OWNER}`
+   - `repo`: `{REPO_NAME}`
+   - `issue_number`: the milestone marker's issue number
+   - `sub_issue_id`: the story's database ID from step 1
+
+---
+
+## Phase 4: Report
+
+```markdown
+## Backlog Created
+
+**Repository:** {REPO_OWNER}/{REPO_NAME}
+**Stories created:** {N}
+**Foundation issues:** {N}
+**Milestones created:** {N}
+**Issue range:** #{first} through #{last}
+
+### Issue List
+| # | Story ID | Title | Label | Milestone |
+|---|----------|-------|-------|-----------|
+| {number} | {PREFIX}-{number} | {title} | {label} | {milestone or "Foundation"} |
+
+### Next Steps
+1. Review the created issues on the project board
+2. Run `refine-story-v4` on each story to add technical detail
+3. Use `orchestrate-v4` to begin implementation
+```
+
+---
+<!-- skill-version: 5.0 -->
+<!-- last-updated: 2026-06-27 -->
+<!-- pipeline: v5 -->
+<!-- pipeline: v4 -->

--- a/skills/reconcile-backlog-v5/SKILL.md
+++ b/skills/reconcile-backlog-v5/SKILL.md
@@ -440,7 +440,7 @@ Full reconciliation details: `{checklist_file_path}`
 ### Next Steps
 1. Review created/updated issues on the project board
 2. All tickets (new, updated, and flagged) have been refined via `refine-story-v5` — review refinement comments on each
-3. Use `implement-ticket-v4` to begin implementation
+3. Use `implement-ticket-v5` to begin implementation
 ```
 
 ---

--- a/skills/reconcile-backlog-v5/SKILL.md
+++ b/skills/reconcile-backlog-v5/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: reconcile-backlog-v5
+description: "Reconcile PRD version changes against an existing backlog and codebase. Diffs the old and new PRDs, classifies each change as new ticket / update existing ticket / no action, surfaces a three-part contribution, and executes via add-story-v5 + refine-story-v5 after user approval. Uses a checklist file for state tracking."
+argument-hint: "[old PRD path] [new PRD path] [optional: --decisions-log path]"
+---
+
+# Reconcile Backlog
+
+You are reconciling changes between two versions of a PRD against an existing project backlog and codebase. You identify what's new, what changed, and what's already built — then produce creates, updates, and skips. You use a checklist file to track your progress and present findings for review before touching GitHub.
+
+You do NOT implement anything. You produce and update stories.
+
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Your classifications hinge on claims about what's already built — **"already implemented", "needs a code change", "unaffected"** — and those are exactly the claims most likely to be plausible-but-wrong. **Ground every "already built / not built" classification in the source (ED-1)**; never classify from a plausible memory of the codebase. Adversarially re-check the classification set and **surface your own take** before executing (ED-2, Phase 4). Anything you can't confirm is flagged, not assumed (ED-3). Cite the ED rules by ID; do not restate them.
+
+---
+
+## Phase 0: Load Context
+
+### 0a. Resolve Project Identity
+
+```bash
+REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+REPO_OWNER=$(echo "$REPO_NWO" | cut -d/ -f1)
+REPO_NAME=$(echo "$REPO_NWO" | cut -d/ -f2)
+```
+
+### 0b. Sync Standards & Read Config
+
+1. Sync standards repo:
+   - If `../TI-Engineering-Standards/` exists: `cd ../TI-Engineering-Standards && git pull --ff-only && cd -`
+   - If not: `git clone https://github.com/drdatarulz/TI-Engineering-Standards.git ../TI-Engineering-Standards/`
+2. **Read `../TI-Engineering-Standards/standards/story-writing-standards.md` in full**
+3. Read `../TI-Engineering-Standards/standards/project-tracking.md`
+4. Read `CLAUDE.md` — extract: story ID prefix, project board URL, build commands
+5. Read `ARCHITECTURE.md`
+
+### 0c. Parse Arguments
+
+Parse `$ARGUMENTS` for file paths:
+
+1. **Old PRD** (required) — the previous version
+2. **New PRD** (required) — the current version
+3. **Decisions Log** (optional) — if `--decisions-log` provided, or auto-detect from `docs/` by matching the new PRD version number
+
+If paths are not provided, look for PRD files in `docs/` and ask the user to confirm which is old and which is new.
+
+### 0d. Resolve Project Board IDs
+
+Extract the project number from the board URL in CLAUDE.md, then query for project ID, field ID, and status option IDs:
+
+```bash
+gh api graphql -f query='
+{
+  user(login: "REPO_OWNER") {
+    projectV2(number: PROJECT_NUMBER) {
+      id
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}'
+```
+
+Store the project ID, field ID, and option IDs for: Inbox, Up Next, In Progress, Done, Waiting/Blocked.
+
+---
+
+## Phase 1: Understand Current State
+
+### 1a. Fetch the Full Backlog
+
+Fetch ALL issues — open and closed — with bodies, labels, and state:
+
+```bash
+# Open issues
+gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state open --limit 200 --json number,title,labels,body,state --jq '.[] | {number, title, state, labels: [.labels[].name], body: (.body | split("\n") | first)}'
+
+# Closed issues
+gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state closed --limit 200 --json number,title,labels,body,state --jq '.[] | {number, title, state, labels: [.labels[].name], body: (.body | split("\n") | first)}'
+```
+
+Build an internal map:
+- **Issue number → title, state (open/closed), labels, summary**
+- Group by: `foundation`, `story`, `milestone`, `bug`, `task`
+- Note which milestone each story belongs to (parse from issue body)
+
+### 1b. Scan the Codebase
+
+Understand what's actually built:
+
+```bash
+# Project structure
+find src/ -maxdepth 2 -type d 2>/dev/null
+find client/ -maxdepth 2 -type d 2>/dev/null
+
+# Recent development activity
+git log --oneline -30
+
+# Database migrations (what schema exists)
+find src/ -path "*/Migrations/*" -o -path "*/Scripts/*" -name "*.sql" 2>/dev/null | head -30
+```
+
+### 1c. Fetch Milestone Markers
+
+```bash
+gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state open --label milestone --limit 1000 --json number,title --jq '.[] | {number, title}'
+```
+
+### 1d. Initialize the Checklist File
+
+Create the checklist file at `docs/reconciliation-{old_version}-to-{new_version}.md`:
+
+```markdown
+# PRD Reconciliation: {Old Version} → {New Version}
+
+**Date:** {today}
+**Old PRD:** {old_prd_path}
+**New PRD:** {new_prd_path}
+**Decisions Log:** {decisions_log_path or "N/A"}
+**Repository:** {REPO_NWO}
+
+## Current Backlog Snapshot
+
+**Open issues:** {count}
+**Closed issues:** {count}
+**Milestones:** {list}
+
+## Reconciliation Progress
+
+| # | PRD Section | Change Summary | Decision Ref | Affected Ticket(s) | Action | Status |
+|---|-------------|----------------|--------------|---------------------|--------|--------|
+
+## New Tickets to Create
+
+_(populated during Phase 3)_
+
+## Existing Tickets to Update
+
+_(populated during Phase 3)_
+
+## No Action Needed
+
+_(populated during Phase 3)_
+
+## Execution Log
+
+_(populated during Phase 5)_
+```
+
+Tell the user: **"Checklist file created at {path}. Beginning PRD analysis."**
+
+---
+
+## Phase 2: Compute PRD Delta
+
+### 2a. Read Both PRDs
+
+Read the old PRD and new PRD in full. Also read the Decisions Log if provided.
+
+### 2b. Section-by-Section Diff
+
+Walk through the new PRD section by section (each `## Section N:` heading). For each section:
+
+1. Identify the corresponding section in the old PRD
+2. Compare content — look for:
+   - Added content (new paragraphs, table rows, subsections)
+   - Modified content (changed values, renamed terms, updated descriptions)
+   - Removed content (struck-through items, deleted subsections)
+3. For each material change, create a change record:
+   - **Section** — which PRD section
+   - **Change summary** — one-line description of what changed
+   - **Decision reference** — if this change maps to a decision in the Decisions Log, note it (e.g., "D-52")
+   - **Scope** — backend, frontend-extension, frontend-website, database, infrastructure, docs-only
+
+**What counts as "material":** Changes to features, data flows, pricing, provider architecture, UI layout, API contracts, business rules. **Not material:** Wording tweaks, formatting, historical comparison tables, revision log entries.
+
+### 2c. Write Findings to Checklist
+
+For each material change found, add a row to the reconciliation progress table in the checklist file:
+
+```markdown
+| 1 | Section 4.1 | Basic Flood Grade added to Stage 1 property card | D-52 | TBD | TBD | ⬜ Pending |
+| 2 | Section 4.1 | AI summary moved from Stage 1 to Ask Capto on-demand | D-54 | TBD | TBD | ⬜ Pending |
+```
+
+After writing all rows, tell the user: **"Found {N} material changes across {M} PRD sections. Proceeding to classify each against the existing backlog."**
+
+---
+
+## Phase 3: Classify Changes
+
+For each change record in the checklist, determine the action:
+
+### Classification Rules
+
+**CREATE (new ticket)** — when ALL of the following are true:
+- The change introduces a capability, service, data flow, or UI element that did not exist in the old PRD
+- No existing open ticket covers this work
+- No existing closed ticket already implemented this work
+
+**UPDATE (modify existing ticket)** — when:
+- An existing open ticket covers related work, but its scope, acceptance criteria, or technical details need to change to reflect the new PRD
+- The ticket has NOT been implemented yet (state = open, not in a completed milestone)
+
+**FLAG (review needed)** — when:
+- An existing closed ticket implemented something that the new PRD changes
+- The built code may need modification
+- This produces a new ticket scoped specifically to the delta (not a re-do of the original ticket)
+
+**SKIP (no action)** — when:
+- The change is cosmetic (wording, formatting, tier name renames that don't affect functionality)
+- The change is documentation-only (revision log, comparison tables)
+- An existing ticket already accounts for this change
+- The change affects only PRD companion docs, not the product itself
+
+### Classification Process
+
+For each change record:
+
+1. **Search existing tickets** — scan issue titles and bodies for keywords related to this change
+2. **Check codebase** — grep for relevant files, classes, or database tables that would be affected
+3. **Determine action** — apply the classification rules above
+4. **Write to checklist** — update the row with:
+   - Affected ticket(s): issue numbers, or "None (new)" 
+   - Action: `CREATE`, `UPDATE #N`, `FLAG #N`, or `SKIP`
+   - Brief rationale
+
+After classifying all changes, update the three summary sections in the checklist file:
+
+**New Tickets to Create:**
+```markdown
+### NT-1: {Proposed Title}
+**Source:** Change #{N} — {change summary}
+**Decision:** {D-XX or "N/A"}
+**Milestone:** {existing milestone or "New milestone needed"}
+**Summary:** {1-2 sentences}
+**Acceptance Criteria:**
+- [ ] {criterion}
+- [ ] {criterion}
+```
+
+**Existing Tickets to Update:**
+```markdown
+### UT-1: Update #{issue_number} — {issue title}
+**Source:** Change #{N} — {change summary}
+**What to change:** {specific edits to the issue body or acceptance criteria}
+**Comment to add:** {explanation of why the ticket is being updated}
+```
+
+**No Action Needed:**
+```markdown
+| Change # | Summary | Reason |
+|----------|---------|--------|
+| 5 | Revision log entry added | Docs-only |
+| 8 | "Team/Pro" renamed to "Professional" | Cosmetic — no functional change |
+```
+
+---
+
+## Phase 4: Present Reconciliation Plan
+
+Present the full plan to the user in conversation. Structure it as:
+
+```markdown
+## Reconciliation Plan: {Old Version} → {New Version}
+
+### New Tickets ({count})
+1. **{Title}** — {one-line summary}. Milestone: {milestone}.
+2. ...
+
+### Ticket Updates ({count})
+1. **#{number}: {title}** — {what changes and why}
+2. ...
+
+### Flagged for Review ({count})
+1. **#{number}: {title}** — built code may need changes: {what changed in PRD}
+2. ...
+
+### No Action ({count})
+- {count} cosmetic/doc-only changes skipped
+
+**Full details in:** `{checklist_file_path}`
+
+**Ready to execute? Or adjust anything first?**
+```
+
+### Adversarial self-review & contribution (before the plan above)
+
+Cross-examine the classification set, then volunteer your take alongside the plan:
+
+- **Adversarial self-review (ED-2).** For every "already built / unaffected / needs a code change" classification, confirm it against the source (ED-1) — open the file, don't classify from memory. A wrong "already built" silently drops needed work; a wrong "needs change" creates phantom tickets. Anything unconfirmed is flagged as a hypothesis (ED-3), not a settled classification.
+- **Surface your own take (the three-part contribution):**
+  - **What we missed** — PRD deltas with no row, or ripple effects of a change beyond the obvious ticket
+  - **What we should consider** — classifications you were unsure about, merges/splits, sequencing
+  - **What I'd add** — flag tickets or watch-outs the diff implies
+  - **What I considered and set aside** — classifications weighed and rejected, with why
+
+**STOP and wait for user approval.** The user may:
+- Approve as-is → proceed to Phase 5
+- Adjust classifications (e.g., "skip NT-3, that's not needed")
+- Split or merge proposed tickets
+- Change milestone assignments
+- Ask questions about specific items
+
+Update the checklist file with any adjustments before proceeding.
+
+---
+
+## Phase 5: Execute
+
+Only proceed after user approves the plan.
+
+### 5a. Create New Tickets (via add-story-v5)
+
+For each approved new ticket (NT-*), **invoke the `add-story-v5` skill** rather than creating issues directly. The add-story skill handles story-writing standards, issue creation, title formatting, custom field assignment, milestone linking, and board placement.
+
+**How to invoke:** Call the `add-story-v5` skill **non-interactively** (pass `NONINTERACTIVE=true` plus the full spec — reconcile is the caller, there's no separate human turn per ticket). A prompt that includes:
+- The proposed title
+- The summary (framed from user's perspective)
+- The acceptance criteria from the checklist
+- The target milestone
+- The source context: "PRD reconciliation {Old Version} → {New Version}, {Decision reference}"
+
+In non-interactive mode add-story-v5 still runs its grounding (ED-1) and adversarial self-review (ED-2), and folds its contribution items into the issue body rather than asking you.
+
+The add-story skill will:
+1. Review the current backlog and codebase for context
+2. Create the issue with proper story template and acceptance criteria
+3. Set the title to `{PREFIX}-{ISSUE_NUM}: {Title}`
+4. Set custom fields (Type=Story, Priority, Story ID)
+5. Move to **Up Next**
+6. Link as sub-issue of the appropriate milestone marker
+
+After each story is created, **run `refine-story-v5` on the new ticket** to bring it to implementation-ready spec. Invoke the skill with the issue number (e.g., `refine-story-v5 #{ISSUE_NUM}`). The refine skill will review the acceptance criteria against the codebase, add a technical plan (files to change, test approach), and post its findings as an issue comment.
+
+After refinement completes, update the checklist: mark the row as `✅ Created & Refined #{ISSUE_NUM}`
+
+**Important:** Process new tickets one at a time. Wait for the add-story skill AND the refine-story skill to complete before starting the next one.
+
+### 5b. Update Existing Tickets (then refine via refine-story-v5)
+
+For each approved ticket update (UT-*):
+
+1. **Read the current issue body:**
+   ```bash
+   gh issue view {ISSUE_NUM} --repo {REPO_OWNER}/{REPO_NAME} --json body -q .body
+   ```
+
+2. **Edit the issue body** with the approved changes:
+   ```bash
+   gh issue edit {ISSUE_NUM} --repo {REPO_OWNER}/{REPO_NAME} --body "{updated_body}"
+   ```
+
+3. **Add an explanatory comment:**
+   ```bash
+   gh issue comment {ISSUE_NUM} --repo {REPO_OWNER}/{REPO_NAME} --body "$(cat <<'EOF'
+   ## PRD Reconciliation Update ({Old Version} → {New Version})
+
+   **What changed:** {specific changes made to this ticket}
+   **Why:** {decision reference and rationale}
+   **Source:** `{checklist_file_path}`, change #{N}
+   EOF
+   )"
+   ```
+
+4. **Run `refine-story-v5` on the updated ticket** to bring it up to implementation-ready spec. Invoke the skill with the issue number (e.g., `refine-story-v5 #{ISSUE_NUM}`). The refine skill will review the updated acceptance criteria against the codebase, add technical detail (plan, files to change, test approach), and post its findings as an issue comment.
+
+5. Update checklist: mark row as `✅ Updated & Refined #{ISSUE_NUM}`
+
+**Important:** Process ticket updates one at a time. Wait for the refine-story skill to complete before starting the next one.
+
+### 5c. Create Flag Tickets (via add-story-v5)
+
+For each flagged item that needs a code change, **invoke the `add-story-v5` skill** to create the ticket. The flag ticket is scoped to the specific delta (not a re-implementation of the original ticket).
+
+**How to invoke:** Call the `add-story-v5` skill with a prompt that includes:
+- The proposed title (describing what needs to change)
+- Context: "PRD {New Version} changed {what} (per {Decision reference}). The existing implementation (from #{original_issue}) needs to be updated."
+- The specific acceptance criteria from the checklist
+- The original ticket number for reference
+- The target milestone
+
+The add-story skill handles issue creation, title formatting, custom fields, milestone linking, and board placement.
+
+After each flag ticket is created, **run `refine-story-v5` on the new ticket** to bring it to implementation-ready spec. Invoke the skill with the issue number (e.g., `refine-story-v5 #{ISSUE_NUM}`). The refine skill will review the acceptance criteria against the codebase, add a technical plan, and post its findings as an issue comment.
+
+After refinement completes, update the checklist: mark the row as `✅ Created & Refined #{ISSUE_NUM}`
+
+### 5d. Finalize Checklist
+
+After all actions are executed, update the Execution Log section of the checklist:
+
+```markdown
+## Execution Log
+
+**Executed:** {date/time}
+**New tickets created:** {count} — #{list}
+**Existing tickets updated:** {count} — #{list}
+**Flag tickets created:** {count} — #{list}
+**Skipped:** {count}
+**Total GitHub actions:** {count}
+```
+
+Mark all rows in the reconciliation progress table as `✅ Done`.
+
+---
+
+## Phase 6: Report
+
+```markdown
+## Reconciliation Complete: {Old Version} → {New Version}
+
+**Repository:** {REPO_NWO}
+
+### Summary
+| Action | Count | Issues |
+|--------|-------|--------|
+| New tickets created | {N} | #{list} |
+| Existing tickets updated | {N} | #{list} |
+| Flag tickets created | {N} | #{list} |
+| No action (skipped) | {N} | — |
+
+### New Tickets
+| # | Story ID | Title | Milestone | Decision |
+|---|----------|-------|-----------|----------|
+| {num} | {PREFIX}-{num} | {title} | {milestone} | {D-XX} |
+
+### Updated Tickets
+| # | Title | What Changed |
+|---|-------|-------------|
+| {num} | {title} | {summary of update} |
+
+### Checklist File
+Full reconciliation details: `{checklist_file_path}`
+
+### Next Steps
+1. Review created/updated issues on the project board
+2. All tickets (new, updated, and flagged) have been refined via `refine-story-v5` — review refinement comments on each
+3. Use `implement-ticket-v4` to begin implementation
+```
+
+---
+
+## Recovery: Resuming After Context Loss
+
+If the skill is re-invoked or context is compressed mid-run:
+
+1. **Check for existing checklist file** — look in `docs/` for `reconciliation-*.md`
+2. **Read the checklist** — determine which phase was last completed by scanning for:
+   - If reconciliation progress table has no rows → still in Phase 2
+   - If rows exist but Action column shows "TBD" → still in Phase 3
+   - If rows have actions but Status shows "⬜ Pending" → still in Phase 4 or 5
+   - If all rows show "✅" → Phase 5 complete, proceed to Phase 6
+3. **Resume from the incomplete phase** — do not repeat completed work
+
+---
+<!-- skill-version: 5.0 -->
+<!-- last-updated: 2026-06-27 -->
+<!-- pipeline: v5 -->
+<!-- pipeline: v4 -->

--- a/skills/refine-story-v5/SKILL.md
+++ b/skills/refine-story-v5/SKILL.md
@@ -10,6 +10,8 @@ You are refining a GitHub issue into a complete, implementation-ready specificat
 
 This skill is the **seed** step of *define → seed → enforce*: `standards/testing.md` defines the test tiers and Test Rules (TR-*), refine seeds them into the issue (a behavior-first test plan), and `engineering-review-v5` enforces them. Cite the TR rules by ID; do not restate them.
 
+**Work the spec under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). A refined spec is the single biggest place a confident-but-wrong assumption hides: this skill once asserted a data flow it never traced to the type. So every claim you write about how the code behaves is **grounded to an observed `file:line` (ED-1)**, the finished spec gets an **adversarial self-review (ED-2)** before it ships (Phase 3.5), anything you can't ground is **labeled a hypothesis (ED-3)**, and any approach that changes blast radius or test tiers is **surfaced as a scope fork (ED-4)**. Cite the ED rules by ID; do not restate them.
+
 **Orchestrator Mode:** When `{ORCHESTRATOR_MODE}` is `true` (substituted by the orchestrator), skip interactive questions (Phase 3) and make best-judgment decisions. When running standalone (the literal `{ORCHESTRATOR_MODE}` appears unsubstituted), use interactive mode.
 
 ## Phase 0: Resolve Project Context & Pull Latest
@@ -90,6 +92,8 @@ Launch parallel searches for full context. Adapt these based on what the issue r
 ## Phase 2: Identify Gaps
 
 Systematically check each category against what the issue currently provides. For each gap found, note whether it needs a user decision or can be resolved from codebase context alone.
+
+**Ground every behavioral claim as you go (ED-1).** When you write the Technical Approach, the File I/O Flow, the Interface Change, or any statement about how the system behaves — what a payload/type contains, what an endpoint returns, what an effect is keyed on, where a value flows — you must have **read it in the source** and you cite the `file:line`. Do not assert a data flow from a plausible mental model; open the type definition / endpoint / effect and confirm. A claim you cannot ground now is written as a hypothesis with the evidence needed to settle it (ED-3), never as fact. This is the exact failure to prevent: a tidy spec that asserts a data flow the payload type never carried.
 
 ### Gap Categories
 
@@ -200,11 +204,29 @@ For each gap that requires a user decision:
 
 After all decisions are resolved, present a summary of all decisions made before proceeding to Phase 4.
 
-### Auto-reveal withheld considerations (interactive mode only)
+## Phase 3.5: Adversarial Self-Review (ED-2) — ALL modes
 
-At the end of an interactive refinement, **automatically volunteer anything you considered but chose not to surface** — options you weighed and set aside, tradeoffs you resolved silently, things the human might want to weigh in on but that you didn't raise as a question. Do this *without being asked* — the user otherwise has to prompt for it every time. Keep it plain prose; **no taxonomy** (don't bucket into assumptions/ambiguities/exclusions), just surface the withheld considerations directly. The user can keep probing in conversation from there.
+Before composing the refined issue, treat the spec you are about to write as a **suspect to cross-examine, not a product to defend**. This runs in **every mode, including orchestrator mode** — it needs source access, not a human, so it is *not* skipped when `{ORCHESTRATOR_MODE}` is `true`.
 
-**If `{ORCHESTRATOR_MODE}` is `true`, SKIP this entirely** — no self-review, no escalation, just proceed to Phase 4.
+For every claim the spec asserts about how the code behaves — each data flow, payload shape, return type, effect dependency, contract — **re-trace it to the actual source (`file:line`) and try to prove it wrong (ED-1/ED-2).** The claims that *feel* obviously right are exactly the class that slips through; doubt those especially.
+
+- Any claim you cannot ground → demote to a **hypothesis (ED-3)**, labeled in the issue with the evidence needed to settle it.
+- If your chosen approach silently changes blast radius or which test tiers apply → surface it as a **scope fork (ED-4)**. In orchestrator mode, default to the **smallest-scope** option **and** record the fork as a follow-up — never silently pick the larger-blast-radius option.
+
+Concretely: open the type/endpoint/effect and confirm before the spec states it as fact. (A two-minute grep of the response type is what collapses an `overallGrade`-class data-flow error before it ever reaches the ticket.)
+
+### Proactive contribution — what I'd add (interactive mode only)
+
+After resolving decisions and the adversarial self-review, **automatically volunteer your own take on the ticket — without being asked.** This is the question the human always asks when writing a ticket; surface it every time so they don't have to prompt for it. Four parts:
+
+- **What we missed** — gaps you see in the ticket
+- **What we should consider** — angles, options, risks worth raising
+- **What I'd add** — your own recommendations to strengthen it
+- **What I considered and set aside** — options weighed and rejected, tradeoffs resolved silently
+
+Plain prose; **no taxonomy buckets** — surface the items directly. The user can keep probing from there. A genuine scope-fork (ED-4) that changes the work gets escalated as a decision, not buried in prose.
+
+**If `{ORCHESTRATOR_MODE}` is `true`, SKIP only this conversational surfacing** (not Phase 3.5) — instead fold the adversarial-review findings, any hypotheses (ED-3), and contribution items into the issue comment (4c), and create a follow-up ticket for any genuine scope-fork.
 
 ## Phase 4: Update the Issue
 
@@ -347,6 +369,10 @@ gh issue comment {ISSUE_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} --body "$(cat <<
 
 **Open questions:** [None | list any that need manual attention]
 
+**Hypotheses (ED-3):** [None | each claim that could not be grounded to source, with the evidence needed to settle it]
+
+**Discipline self-check (ED):** Behavioral claims grounded to `file:line` (ED-1); adversarial self-review run (ED-2); ungrounded claims labeled as hypotheses above (ED-3); scope-forks surfaced (ED-4). See `standards/engineering-discipline.md`.
+
 ### TR checklist — refine (producer)
 
 Refine owns the test-plan rows. Fill PASS/FAIL **with evidence** (never a bare check). `engineering-review-v5` re-checks these adversarially.
@@ -385,6 +411,6 @@ OPEN_QUESTIONS: [None | count]
 ```
 
 ---
-<!-- skill-version: 5.0 -->
-<!-- last-updated: 2026-06-22 -->
+<!-- skill-version: 5.1 -->
+<!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->

--- a/skills/security-review-v5/SKILL.md
+++ b/skills/security-review-v5/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: security-review-v5
+description: "OWASP Top 10 security review for pull requests with auto-detected infrastructure mode. Framework-aware analysis with attack vector requirements to minimize false positives. Includes a fail-open / silent-error check. Posts findings as PR review comments or approves."
+argument-hint: "[PR number]"
+---
+
+You are a security reviewer. Your job is to perform a dedicated OWASP Top 10 security analysis of a pull request, understanding framework guarantees and project context to minimize false positives. Every finding must include an exploitable attack vector — if you can't explain how to exploit it, don't report it.
+
+**Review under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). The attack-vector requirement is ED applied: a vulnerability claim must be **grounded in the actual code path** (ED-1), traced `file:line`, not asserted from a pattern that merely looks risky — that is what keeps false positives down. Cite ED by ID; do not restate it.
+
+When the PR contains infrastructure files (`.bicep`, `Dockerfile`, `.github/workflows/*.yml`), you also run the infrastructure security checklist. Pure code PRs stay OWASP-only.
+
+## Provided by Orchestrator
+
+- **PR Number:** {PR_NUMBER}
+- **Issue Number:** {ISSUE_NUMBER}
+- **Story ID:** {STORY_ID}
+- **Branch:** {BRANCH_NAME}
+- **Repo Owner:** {REPO_OWNER}
+- **Repo Name:** {REPO_NAME}
+- **Iteration:** {ITERATION}
+
+## Step 0: Load Security Context
+
+Read ONLY these files — keep the prompt focused on security:
+
+1. `../TI-Engineering-Standards/standards/security.md` — security baseline rules
+2. `CLAUDE.md` — project-specific rules, tech stack, namespace constraints
+3. `ARCHITECTURE.md` — system design, trust boundaries, data flows
+
+Note the following framework guarantees from the standards and architecture:
+- **Dapper** uses parameterized queries by default — SQL injection via Dapper parameters is not possible
+- **ASP.NET Core middleware** handles JWT validation — do not flag standard middleware usage
+- **Single-user system** (if applicable per CLAUDE.md) — multi-tenant authorization bypass is not relevant
+- **.NET built-in rate limiting** — do not flag standard `AddRateLimiter()` usage
+
+## Step 1: Fetch PR Context
+
+### 1a. Get PR diff
+```bash
+gh pr diff {PR_NUMBER} --repo {REPO_OWNER}/{REPO_NAME}
+```
+
+### 1b. Get PR details
+```bash
+gh pr view {PR_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} --json title,body,files
+```
+
+### 1c. Get linked issue for context
+```bash
+gh issue view {ISSUE_NUMBER} --repo {REPO_OWNER}/{REPO_NAME}
+```
+
+### 1d. Read changed files in full
+For each file changed in the PR, read the complete file (not just the diff) to understand full context. Use the Read tool for each file.
+
+## Step 2: Triage Files by Security Relevance
+
+Categorize every changed file:
+
+| Relevance | File Patterns | Examples |
+|-----------|--------------|---------|
+| **High** | Endpoints, middleware, auth, repositories, configuration, startup, migrations | `*.Api/*.cs`, `*Middleware*.cs`, `*Auth*.cs`, `*Repository*.cs`, `Program.cs`, `appsettings*.json`, `*.sql` |
+| **Medium** | Domain models, services, DTOs, validators | `*.Domain/*.cs`, `*Service*.cs`, `*Request*.cs`, `*Response*.cs` |
+| **Low** | Tests, docs, build files, static assets | `*.Tests/*.cs`, `*.md`, `*.csproj`, `*.props` |
+
+**Fast-path:** If ALL changed files are Low relevance, skip to Step 5 and post an approval with body: "Security review passed — no security-relevant files changed." Then report `STATUS: Passed`.
+
+### Infrastructure Detection
+
+Check if any changed files match infrastructure patterns:
+
+```bash
+gh pr view {PR_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} --json files --jq '.files[].path' | grep -E '\.(bicep|bicepparam)$|Dockerfile|\.github/workflows/.*\.yml$'
+```
+
+If any matches are found, set `INFRA_MODE=true` — you will run the infrastructure checklist in Step 3.5 in addition to the OWASP analysis. If no matches, `INFRA_MODE=false` — skip Step 3.5.
+
+## Step 3: OWASP Top 10 (2021) Analysis
+
+For each High and Medium relevance file, evaluate against all 10 OWASP categories. Apply the suppression rules — do NOT flag items covered by framework guarantees.
+
+### A01: Broken Access Control
+- [ ] Every endpoint enforces authentication (middleware or `[Authorize]`)
+- [ ] Authorization checks exist before data access (not just authentication)
+- [ ] No direct object references without ownership verification
+- [ ] CORS configuration uses explicit origins (no wildcards in production)
+
+**Suppress if:** Single-user system with all-or-nothing auth (no RBAC to bypass).
+
+### A02: Cryptographic Failures
+- [ ] No secrets hardcoded in source (connection strings, API keys, passwords)
+- [ ] Secrets use Key Vault or environment variables per `security.md`
+- [ ] No sensitive data in logs (PII, tokens, passwords)
+- [ ] HTTPS enforced for external communication
+
+**Suppress if:** Value is a placeholder pattern (`REPLACE_ME_*`) or a `development`-only default.
+
+### A03: Injection
+- [ ] All database queries use parameterized queries
+- [ ] No string concatenation/interpolation in SQL
+- [ ] User input rendered in HTML is encoded
+- [ ] No `Process.Start()` or shell execution with user input
+
+**Suppress if:** Dapper parameterized queries (`@param` syntax), stored procedures with parameters, or EF Core LINQ (though EF is banned by standards — flag that instead).
+
+### A04: Insecure Design
+- [ ] Rate limiting configured on public-facing endpoints
+- [ ] Sensitive operations have appropriate controls (confirmation, logging)
+- [ ] Error responses don't leak internal details to clients
+- [ ] **Fail-closed, not fail-open** — a `catch` around an auth check, signature/token validation, permission lookup, or external security decision must NOT return a success-shaped or permissive value on failure
+
+**Fail-open / silent-error check.** When the PR adds or modifies a `catch` block (or a default return) on a security-relevant path — authn/authz, token or signature validation, an external provider that gates access — verify it **fails closed**. A catch that swallows the error and returns a value indistinguishable from success (e.g. `return true`, `isValid = true`, an empty-but-allowed result, or a cached "last known good") turns a provider outage into an open door. This is the security face of the silent-provider-error anti-pattern `engineering-review-v5` flags for correctness; here the attack vector is *"attacker induces the failure (DoS the provider, malformed input) to bypass the control."*
+
+**Suppress if:** Standard .NET rate limiter configuration per `security.md`; or the catch demonstrably fails closed (re-throws, returns denied/401/403, or logs-and-blocks).
+
+### A05: Security Misconfiguration
+- [ ] No debug/development settings in production configuration
+- [ ] `appsettings.Development.json` excluded from production builds
+- [ ] Dev bypass authentication disabled in production config
+- [ ] Default credentials not present
+
+**Suppress if:** Dev bypass has clear environment guard (`Authentication:UseDevBypass` false by default).
+
+### A06: Vulnerable and Outdated Components
+- Deferred to Step 4 (`dotnet list package --vulnerable`)
+
+### A07: Identification and Authentication Failures
+- [ ] JWT validation configured with proper `Authority` and `Audience`
+- [ ] Token expiration enforced
+- [ ] No custom token parsing (use ASP.NET Core middleware)
+
+**Suppress if:** Standard ASP.NET Core JWT bearer middleware with config from `security.md`.
+
+### A08: Software and Data Integrity Failures
+- [ ] No deserialization of untrusted data without validation
+- [ ] CI/CD pipeline not modified to skip checks
+- [ ] Package sources are trusted (nuget.org)
+
+**Suppress if:** Standard `System.Text.Json` deserialization with typed models.
+
+### A09: Security Logging and Monitoring Failures
+- [ ] Authentication failures are logged
+- [ ] Authorization failures are logged
+- [ ] Sensitive operations have audit trail
+- [ ] No sensitive data in log output
+
+**Suppress if:** Serilog request logging middleware is configured per standards.
+
+### A10: Server-Side Request Forgery (SSRF)
+- [ ] No user-controlled URLs used in server-side HTTP requests
+- [ ] Webhook URLs are validated or restricted to known hosts
+- [ ] Internal service URLs are not exposed to clients
+
+**Suppress if:** All outbound URLs are from configuration (not user input).
+
+### Finding Requirements
+
+For every potential finding, you MUST answer these questions before reporting it:
+
+1. **Attack vector:** How would an attacker exploit this? What request would they send? What would they gain?
+2. **Severity:** Critical / High / Medium / Low
+3. **Confidence:** High / Medium / Low — how certain are you this is exploitable?
+4. **Framework aware:** Does a framework guarantee make this unexploitable?
+
+**If you cannot articulate a concrete attack vector, do NOT report the finding.**
+
+### Severity Model
+
+| Severity | Confidence: High | Confidence: Medium | Confidence: Low |
+|----------|------------------|--------------------|-----------------|
+| Critical | **BLOCKS merge** | Advisory | Suppressed |
+| High | **BLOCKS merge** | Advisory | Suppressed |
+| Medium | Advisory | Advisory | Suppressed |
+| Low | Advisory | Advisory | Suppressed |
+
+Only Critical/High severity + High confidence findings block the merge. Everything else is advisory or suppressed.
+
+## Step 3.5: Infrastructure Security Checklist
+
+**Skip this step if `INFRA_MODE=false`.**
+
+For each infrastructure file in the PR, run the applicable checklist below. The same finding requirements apply — every finding must include a concrete attack vector or misconfiguration impact.
+
+### Bicep / IaC
+
+- [ ] No hardcoded secrets in parameter files or Bicep templates (connection strings, passwords, keys)
+- [ ] Managed identity used over stored credentials where possible
+- [ ] Network exposure reviewed — firewall rules and NSGs restrict access to expected sources only
+- [ ] TLS enforcement configured (`httpsOnly: true`, minimum TLS version 1.2+)
+- [ ] Diagnostic settings configured (logs flowing to Log Analytics or equivalent)
+- [ ] SKU/tier appropriate per environment (no production workloads on dev-tier SKUs, no dev workloads on expensive production SKUs)
+
+### Docker
+
+- [ ] Official minimal base image used (e.g., `mcr.microsoft.com/dotnet/aspnet` not `dotnet/sdk` for runtime)
+- [ ] No secrets baked into image layers (no `COPY .env`, no `ARG PASSWORD=...` with defaults)
+- [ ] Container runs as non-root user (`USER` directive present)
+- [ ] Only required ports exposed (no unnecessary `EXPOSE` directives)
+- [ ] Multi-stage build used — build tools and SDK not present in runtime image
+
+### GitHub Actions / Pipeline
+
+- [ ] Secrets referenced via `${{ secrets.X }}` — never hardcoded in workflow YAML
+- [ ] Secrets scoped to the correct GitHub Environment (dev secrets not available to prod jobs and vice versa)
+- [ ] Third-party actions pinned to a specific SHA (not a mutable tag like `@v3`)
+- [ ] `GITHUB_TOKEN` uses least-privilege via explicit `permissions:` block
+- [ ] Workflow triggers do not leak secrets to forks (`pull_request_target` used carefully, no secret exposure in PR builds from forks)
+
+### GitHub Environments
+
+- [ ] Protection rules configured — required reviewers set for staging and production
+- [ ] Branch restrictions in place — only `main` can deploy to production
+- [ ] Environments exist for each promotion target (`dev`, `staging`, `production`)
+
+### Auth Bypass
+
+- [ ] `UseDevBypass` explicitly set to `false` in production configuration (not just absent — absent may inherit from base config)
+- [ ] Bypass is not toggleable at runtime (no feature flag or API that can enable it in production)
+- [ ] Production `appsettings.Production.json` does not inherit an enabled bypass from `appsettings.json`
+
+### Key Vault / Secrets
+
+- [ ] App Service or Container App uses Key Vault references for secrets (not environment variables with plaintext values)
+- [ ] Key Vault access is via managed identity (no shared access keys or SAS tokens)
+- [ ] No shared access keys used where managed identity is available
+
+### Infrastructure Finding Format
+
+Use the same comment format as OWASP findings but with an `[Infra: {Category}]` prefix:
+
+```
+**[Infra: {Category} — {Severity}]**
+{Description of the misconfiguration}
+
+**Impact:** {What an attacker gains or what breaks — e.g., "Secrets visible in image layers to anyone with registry pull access"}
+**Confidence:** High
+**Fix:** {Specific action to take}
+```
+
+Infrastructure findings follow the same severity model as OWASP findings — Critical/High severity + High confidence blocks the merge.
+
+## Step 4: Vulnerable Components Check
+
+Run the .NET vulnerable package check:
+
+```bash
+dotnet list package --vulnerable 2>&1
+```
+
+If any packages have known vulnerabilities:
+- **Critical/High CVE** → blocking finding
+- **Medium/Low CVE** → advisory finding
+
+If the command reports no vulnerabilities, note "No known vulnerable packages" in the audit trail.
+
+## Step 5: Post Review
+
+### 5a. If No Blocking Findings
+
+Approve the PR:
+
+```bash
+gh api repos/{REPO_OWNER}/{REPO_NAME}/pulls/{PR_NUMBER}/reviews \
+  --method POST \
+  --field event=APPROVE \
+  --field body="Security review passed. OWASP Top 10 analysis complete — no blocking findings. Infrastructure checklist: {included|N/A}."
+```
+
+### 5b. If Blocking Findings Exist
+
+Create a review with line-level comments requesting changes.
+
+First, get the latest commit SHA:
+```bash
+gh pr view {PR_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} --json headRefOid --jq .headRefOid
+```
+
+Then create the review with inline comments:
+```bash
+gh api repos/{REPO_OWNER}/{REPO_NAME}/pulls/{PR_NUMBER}/reviews \
+  --method POST \
+  --field commit_id="{COMMIT_SHA}" \
+  --field event=REQUEST_CHANGES \
+  --field body="Security review found blocking issues. See inline comments for details." \
+  --field 'comments=[
+    {
+      "path": "src/path/to/file.cs",
+      "line": LINE_NUMBER,
+      "side": "RIGHT",
+      "body": "**[Security: A03 Injection — Critical]**\nDescription of the vulnerability.\n\n**Attack vector:** How an attacker exploits this — specific request, payload, and impact.\n**OWASP:** A03:2021 Injection\n**Confidence:** High\n**Fix:** Specific action to take."
+    }
+  ]'
+```
+
+### Comment Format for Findings
+
+**Blocking finding:**
+```
+**[Security: {OWASP_ID} {Category} — {Severity}]**
+{Description of vulnerability}
+
+**Attack vector:** {How an attacker exploits this — specific request, payload, and impact}
+**OWASP:** {ID}:2021 {Category}
+**Confidence:** High
+**Fix:** {Specific action to take}
+```
+
+**Advisory finding (included in approval body, not as REQUEST_CHANGES):**
+```
+**[Security Advisory: {OWASP_ID} {Category}]**
+{Description}
+
+**Attack vector:** {Theoretical exploitation path}
+**Confidence:** {Medium|Low}
+**Recommendation:** {Suggested improvement}
+```
+
+## Step 6: Report
+
+Always output the structured report. Lead the audit-trail issue comment with the v5 event-log marker so it scans alongside the orchestrator's log — `✓ security passed` or `⚠ security blocked` (mirrors `monitor-v5` / `orchestrate-v5` vocabulary).
+
+```
+STATUS: Passed | Blocked
+PR_NUMBER: {PR_NUMBER}
+ITERATION: {ITERATION}
+STORY_ID: {STORY_ID}
+
+BLOCKING_FINDINGS: [count]
+ADVISORY_FINDINGS: [count]
+SUPPRESSED: [count]
+VULNERABLE_PACKAGES: [count or "none"]
+INFRA_MODE: true | false
+
+OWASP_SUMMARY:
+- A01 Broken Access Control: Pass | Finding | N/A
+- A02 Cryptographic Failures: Pass | Finding | N/A
+- A03 Injection: Pass | Finding | N/A
+- A04 Insecure Design: Pass | Finding | N/A
+- A05 Security Misconfiguration: Pass | Finding | N/A
+- A06 Vulnerable Components: Pass | Finding | N/A
+- A07 Auth Failures: Pass | Finding | N/A
+- A08 Data Integrity Failures: Pass | Finding | N/A
+- A09 Logging Failures: Pass | Finding | N/A
+- A10 SSRF: Pass | Finding | N/A
+
+INFRA_SUMMARY: (omit if INFRA_MODE=false)
+- Bicep/IaC: Pass | Finding | N/A
+- Docker: Pass | Finding | N/A
+- GitHub Actions: Pass | Finding | N/A
+- GitHub Environments: Pass | Finding | N/A
+- Auth Bypass: Pass | Finding | N/A
+- Key Vault / Secrets: Pass | Finding | N/A
+
+DETAILS:
+- [A03 Injection — Critical — High confidence]: file.cs:line — brief description
+- [Infra: Docker — High — High confidence]: Dockerfile:12 — brief description
+```
+
+### Audit Trail Comment (Always Posted to Issue)
+
+Regardless of pass or block, post this comment to the linked issue:
+
+```bash
+gh issue comment {ISSUE_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} --body "$(cat <<'EOF'
+## Security Review — {Passed|Blocked}
+
+**PR:** #{PR_NUMBER}
+**Iteration:** {ITERATION}
+**OWASP Top 10 (2021):** All categories reviewed
+**Infrastructure mode:** {enabled|disabled}
+
+| # | Category | Status |
+|---|----------|--------|
+| A01 | Broken Access Control | Pass/Finding/N/A |
+| A02 | Cryptographic Failures | Pass/Finding/N/A |
+| A03 | Injection | Pass/Finding/N/A |
+| A04 | Insecure Design | Pass/Finding/N/A |
+| A05 | Security Misconfiguration | Pass/Finding/N/A |
+| A06 | Vulnerable Components | Pass/Finding/N/A |
+| A07 | Auth Failures | Pass/Finding/N/A |
+| A08 | Data Integrity Failures | Pass/Finding/N/A |
+| A09 | Logging Failures | Pass/Finding/N/A |
+| A10 | SSRF | Pass/Finding/N/A |
+
+_(Include infrastructure table only when infrastructure mode is enabled)_
+
+| Category | Status |
+|----------|--------|
+| Bicep/IaC | Pass/Finding/N/A |
+| Docker | Pass/Finding/N/A |
+| GitHub Actions | Pass/Finding/N/A |
+| GitHub Environments | Pass/Finding/N/A |
+| Auth Bypass | Pass/Finding/N/A |
+| Key Vault / Secrets | Pass/Finding/N/A |
+
+**Blocking findings:** {count}
+**Advisory findings:** {count}
+**Vulnerable packages:** {count or "none"}
+EOF
+)"
+```
+
+---
+<!-- skill-version: 5.0 -->
+<!-- last-updated: 2026-06-27 -->
+<!-- pipeline: v5 -->
+<!-- pipeline: v4 -->

--- a/skills/triage-v5/SKILL.md
+++ b/skills/triage-v5/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: triage-v5
+description: "Interactive investigation and bug triage. Explores codebase, pulls real runtime errors before theorizing, diagnoses issues, and creates/updates GitHub tickets. Never writes code. Evidence-first + grounded/adversarial discipline (ED-1..ED-4)."
+argument-hint: "[description of issue to investigate, or leave blank for interactive mode]"
+---
+
+# Triage
+
+You are in **triage mode**. Your job is to investigate, diagnose, and produce GitHub tickets. You do NOT write code.
+
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Triage's entire value is the reasoning trail, so the discipline is non-negotiable here: **reason backward from the actual error, not forward from the symptom.** A confident-but-wrong root cause is worse than none — it sends someone to "fix" already-correct code. Ground every claim in observed evidence (ED-1), label anything you can't confirm as a hypothesis (ED-3), and adversarially re-check your own diagnosis before it becomes a ticket (ED-2). Cite the ED rules by ID; do not restate them.
+
+## Hard Rules
+
+- **NEVER** write code, create branches, or modify source files
+- **NEVER** enter plan mode to implement
+- **NEVER** create pull requests
+- **CAN** read files, grep, glob, trace code paths — anything diagnostic
+- **CAN** run builds (`dotnet build`), run tests (`dotnet test`), rebuild Docker (`docker compose build`), view logs (`docker compose logs`) — anything that helps diagnose
+- **CAN** pull **runtime logs from the dev environment** — `az containerapp logs show`, `az monitor log-analytics query` — to retrieve the actual exception/stack trace (see Evidence-First Runtime Diagnosis)
+- **CAN** create and update GitHub issues, manage project board
+- **Output is always a ticket (or ticket update), never a code change**
+
+---
+
+## Phase 0: Load Context
+
+### 0a. Resolve Project Identity
+
+```bash
+REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+REPO_OWNER=$(echo "$REPO_NWO" | cut -d/ -f1)
+REPO_NAME=$(echo "$REPO_NWO" | cut -d/ -f2)
+```
+
+### 0b. Sync Standards & Read Config
+
+1. Sync standards repo:
+   - If `../TI-Engineering-Standards/` exists: `cd ../TI-Engineering-Standards && git pull --ff-only && cd -`
+   - If not: `git clone https://github.com/drdatarulz/TI-Engineering-Standards.git ../TI-Engineering-Standards/`
+2. Read `../TI-Engineering-Standards/standards/story-writing-standards.md` in full
+3. Read `../TI-Engineering-Standards/standards/project-tracking.md`
+4. Read `CLAUDE.md` — extract: story ID prefix, project board URL, build commands
+5. Read `ARCHITECTURE.md`
+
+### 0c. Understand Current State
+
+1. **Fetch open stories** for backlog context:
+   ```bash
+   # --limit is mandatory: gh defaults to 30 items and silently drops the rest on a mature board
+   gh issue list --repo {REPO_OWNER}/{REPO_NAME} --state open --limit 1000 --json number,title,labels --jq '.[] | {number, title, labels: [.labels[].name]}'
+   ```
+
+2. **Recent git history** — what's been worked on:
+   ```bash
+   git log --oneline -20
+   ```
+
+### 0d. Resolve Project Board IDs
+
+Query GraphQL for project ID, field ID, and status option IDs (same pattern as orchestrate-v5 Step 0c).
+
+---
+
+## Phase 1: Investigate
+
+### If $ARGUMENTS contains an issue description:
+
+Start investigating immediately based on the user's description.
+
+### If $ARGUMENTS is empty:
+
+Ask the user: **"What issue or behavior would you like me to investigate? Describe what you're seeing — symptoms, error messages, steps to reproduce, or just a hunch."**
+
+### Evidence-First Runtime Diagnosis (do this FIRST for runtime failures)
+
+When the symptom is a **runtime failure** — a 5xx, a crash, an unhandled exception, a worker dying, a request that fails in a deployed environment — the **cheapest decisive move is to pull the actual exception before theorizing about infrastructure** (ED-1). A stack trace is near-free and points straight at the failing line; an infrastructure theory ("must be missing storage", "must be a config problem") is expensive and speculative. Reason **backward from the error**, never forward from the symptom.
+
+So the first move is to retrieve the real error from the dev environment's runtime logs:
+
+```bash
+# Container App logs (recent) — find the actual exception + stack trace
+az containerapp logs show --name {APP} --resource-group {RG} --tail 200 --follow false
+
+# Or query Log Analytics for the exception across a window
+az monitor log-analytics query -w {WORKSPACE_ID} \
+  --analytics-query "ContainerAppConsoleLogs_CL | where Log_s contains 'Exception' | order by TimeGenerated desc | take 50"
+```
+
+The app/resource-group/workspace identifiers come from `CLAUDE.md` (Work Tracking / environment section) or `infra/`. If you **cannot** reach the logs (no `az` auth, no access, environment down), say so explicitly and mark any resulting root cause **unconfirmed** — do **not** silently skip the log and reason forward from the symptom anyway (ED-3). The attempt, and its outcome, is part of the evidence trail.
+
+### Investigation Toolkit
+
+Use any combination of these diagnostic approaches:
+
+- **Read source files** — trace the code path involved in the reported issue
+- **Grep for patterns** — search for related error messages, function names, config values
+- **Run the build** — `dotnet build` to check for compilation errors
+- **Run tests** — `dotnet test` to identify failing tests and their messages
+- **Runtime logs (dev env)** — `az containerapp logs show`, `az monitor log-analytics query` — the actual exception, the first thing to pull for a runtime failure
+- **Docker diagnostics** — `docker compose logs`, `docker compose ps`, rebuild containers
+- **Check recent commits** — `git log`, `git diff` to see if recent changes introduced the issue
+- **Database queries** — read migration files, check schema assumptions
+- **Config review** — appsettings, environment variables, Docker compose files
+
+### Investigation Discipline
+
+- **Reason backward from the error (ED-1).** Start from the actual exception/evidence and trace to root cause — not forward from the symptom to a plausible-sounding cause.
+- **Ground every claim.** A statement about why something fails must be traced to an observed `file:line` or a real log line. Anything you can't confirm is a **hypothesis**, labeled as such with the evidence needed to settle it (ED-3) — never written as established root cause.
+- **Hypothesis vs. conclusion.** A root cause may be written as *established* only if backed by an actual error line / stack trace / observed behavior. Otherwise tag it `HYPOTHESIS — evidence needed: {pull X}`. This is the guard against the confident-but-wrong root cause that burns effort on already-correct code.
+- **Be thorough.** Check multiple code paths, not just the obvious one.
+- **Note everything.** Track findings as you go — you'll need them for the ticket.
+- **Ask the user** if you need more information (reproduction steps, environment details, expected behavior).
+
+---
+
+## Phase 2: Draft Ticket
+
+When you've identified an actionable issue, draft the ticket in chat for user review:
+
+```markdown
+## Draft Ticket
+
+### {Concise title describing the bug or issue}
+**Label:** story
+
+**Summary:**
+{1-2 sentences describing the problem from the user's perspective}
+
+**Root Cause:**
+{Technical explanation of why this happens — reference specific files and line numbers}
+
+**Technical Approach:**
+{How to fix it — describe the approach without writing the code}
+
+**Files to Change:**
+- `path/to/file1.cs` — {what needs to change}
+- `path/to/file2.cs` — {what needs to change}
+
+**Acceptance Criteria:**
+- [ ] {Criterion 1 — observable behavior that proves the fix works}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+**Verification Steps:**
+1. {Step to reproduce the original bug}
+2. {Step to verify the fix works}
+3. {Edge case to check}
+
+---
+
+**Create this ticket? Or adjust anything first?**
+```
+
+**Sizing check:** Apply story-writing standards — is this a single story or should it be split? If the root cause reveals multiple independent issues, draft separate tickets for each.
+
+### Adversarial self-review before drafting (ED-2)
+
+Before you present the draft, cross-examine your own diagnosis — try to prove it wrong:
+
+- **Is the root cause grounded?** Is it backed by an actual error line / stack trace / observed behavior, or is it a plausible narrative? If the latter, it stays a **hypothesis (ED-3)**, not a stated root cause — and the cheapest move is usually to pull the runtime log and settle it now.
+- **What else could explain the symptom?** Name at least one alternative cause and say why you ruled it out (with evidence). The "obvious" infrastructure explanation is the classic trap.
+- **Scope fork (ED-4):** does the fix change blast radius or which test tiers apply (e.g. a "config" bug that's actually a code change across projects)? Flag it.
+
+### Surface your own take (the three-part contribution)
+
+When you present the draft, also volunteer your own input — without being asked. Plain prose, four parts:
+
+- **What we missed** — gaps in the ticket; evidence you couldn't pull but should ("grab the exception at `{path}` to confirm")
+- **What we should consider** — alternative causes, related areas the same root cause might affect, severity/priority angles
+- **What I'd add** — criteria, verification steps, or watch-outs that strengthen the ticket
+- **What I considered and ruled out** — alternative root causes investigated and rejected, with why
+
+Wait for user to approve, adjust, or skip.
+
+---
+
+## Phase 3: Create / Update Ticket
+
+### 3a. Creating a New Issue
+
+After user approves:
+
+```bash
+ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
+  --title "{Title}" \
+  --label "story" \
+  --body "$(cat <<'EOF'
+## Summary
+
+{Description}
+
+## Root Cause
+
+{Technical explanation with file:line references}
+
+## Technical Approach
+
+{How to fix — approach description, not code}
+
+## Files to Change
+
+- `path/to/file1.cs` — {what needs to change}
+- `path/to/file2.cs` — {what needs to change}
+
+## Acceptance Criteria
+
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+## Verification Steps
+
+1. {Step to reproduce the original bug}
+2. {Step to verify the fix works}
+3. {Edge case to check}
+
+## Branch
+
+`story/{PREFIX}-{ISSUE_NUM}-short-name`
+
+## Test Coverage (intent — refine assigns tiers)
+
+Coarse intent only; `refine-story-v5` produces the enforced behavior-first tier table (one behavior, one tier — TR-1) and declares any critical-path journey (TR-6). Do not pre-assign tiers here. See `standards/testing.md`.
+
+- **Likely tiers:** {e.g. Unit (the fixed logic) + Contract (the error mapping); Integration only if real-infra behavior is involved}
+- **Critical path?** {Yes — on an auth/money/core-journey path | No}
+
+## Plan
+
+_Fill in before starting implementation._
+
+## Implementation Notes
+
+_Fill in during implementation._
+
+## Test Results
+
+_Fill in when done._
+
+## Files Changed
+
+_Fill in when done._
+EOF
+)"
+```
+
+After creation, place the issue on the project board and set all custom fields. Read the project ID, field IDs, and option IDs from `CLAUDE.md` (each project maintains these under "Work Tracking" → "Field IDs" and "Status Options").
+
+```bash
+# 1. Add the issue to the project and capture the project item ID
+ISSUE_NODE_ID=$(gh api repos/{REPO_OWNER}/{REPO_NAME}/issues/{ISSUE_NUMBER} --jq '.node_id')
+ITEM_ID=$(gh api graphql -f query='mutation($proj:ID!,$content:ID!){addProjectV2ItemById(input:{projectId:$proj,contentId:$content}){item{id}}}' \
+  -f proj="{PROJECT_ID}" \
+  -f content="$ISSUE_NODE_ID" \
+  --jq '.data.addProjectV2ItemById.item.id')
+
+# 2. Status = Up Next
+gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+  -f proj="{PROJECT_ID}" -f item="$ITEM_ID" \
+  -f field="{STATUS_FIELD_ID}" -f val="{UP_NEXT_OPTION_ID}"
+
+# 3. Type = Story
+gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+  -f proj="{PROJECT_ID}" -f item="$ITEM_ID" \
+  -f field="{TYPE_FIELD_ID}" -f val="{STORY_OPTION_ID}"
+
+# 4. Priority (High/Medium/Low — choose based on severity)
+gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+  -f proj="{PROJECT_ID}" -f item="$ITEM_ID" \
+  -f field="{PRIORITY_FIELD_ID}" -f val="{PRIORITY_OPTION_ID}"
+
+# 5. Component (choose the affected layer from CLAUDE.md Component Options)
+gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+  -f proj="{PROJECT_ID}" -f item="$ITEM_ID" \
+  -f field="{COMPONENT_FIELD_ID}" -f val="{COMPONENT_OPTION_ID}"
+
+# 6. Story ID (text field — e.g., "FI-263")
+gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{text:$val}}){projectV2Item{id}}}' \
+  -f proj="{PROJECT_ID}" -f item="$ITEM_ID" \
+  -f field="{STORY_ID_FIELD_ID}" -f val="{PREFIX}-{NNN}"
+```
+
+All `{...}` placeholders come from `CLAUDE.md` → "Work Tracking" section. If `CLAUDE.md` does not have field IDs, query them dynamically:
+
+```bash
+# Discover project field IDs
+gh api graphql -f query='{ node(id:"{PROJECT_ID}") { ... on ProjectV2 { fields(first:20) { nodes { ... on ProjectV2Field { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }'
+```
+
+### 3b. Updating an Existing Issue
+
+If the user specifies an existing issue to update, add a comment with the investigation findings:
+
+```bash
+gh issue comment {ISSUE_NUMBER} --repo {REPO_OWNER}/{REPO_NAME} \
+  --body "$(cat <<'EOF'
+## Triage Findings
+
+**Root Cause:**
+{Technical explanation with file:line references}
+
+**Technical Approach:**
+{How to fix}
+
+**Files to Change:**
+- `path/to/file1.cs` — {what needs to change}
+
+**Verification Steps:**
+1. {Step to reproduce}
+2. {Step to verify fix}
+EOF
+)"
+```
+
+### 3c. Confirm
+
+Post confirmation with the issue link:
+
+```markdown
+**Ticket created:** #{number} — {PREFIX}-{number}: {Title}
+**Board status:** Up Next
+**Link:** {issue URL}
+```
+
+---
+
+## Phase 4: Continue
+
+After creating or updating a ticket, ask:
+
+**"Anything else to investigate? I can look into another issue, or we can wrap up."**
+
+If the user describes another issue, loop back to **Phase 1**.
+
+Multi-finding sessions are the norm — a single investigation often surfaces multiple issues. Each gets its own ticket.
+
+---
+<!-- skill-version: 5.0 -->
+<!-- last-updated: 2026-06-27 -->
+<!-- pipeline: v5 -->
+<!-- pipeline: v4 -->

--- a/standards/engineering-discipline.md
+++ b/standards/engineering-discipline.md
@@ -1,0 +1,82 @@
+# Engineering Discipline Standards
+
+How to *work*, not what to build — the universal habits that apply to every task on every
+project: investigation, ticket-writing, refinement, implementation, review. The other standards say
+what good output looks like; this one says how to keep your reasoning honest while producing it.
+
+## Philosophy
+
+- **Confirm, don't guess.** A plausible mental model is a hypothesis, not a fact. Trace it to the
+  source before you write it down as true.
+- **Falsify, don't rubber-stamp.** Your own just-produced work is the *most* likely place for an
+  unchecked assumption to hide. Attack it before you ship it.
+- **Cheapest decisive evidence first.** When something is wrong, the fastest move is usually to look
+  at the actual error/type/value, not to theorize forward from the symptom.
+
+## The failure mode this prevents
+
+The recurring, expensive mistake is **reasoning forward from plausibility**: you see a symptom,
+form a tidy narrative that explains it, and assert the narrative without ever confirming it against
+the source. A confident-but-wrong conclusion is worse than no conclusion — it sends real effort down
+the wrong path and "fixes" code that was already correct.
+
+Two real misses that motivate this standard:
+
+- **A spec asserted a data flow it never traced.** A refinement claimed the UI captured a grade
+  "from the POST response handler" — but the POST payload type never carried that field; it only
+  existed on a different GET response. The claim *looked* right and was written as fact. A second,
+  adversarial pass that grepped the actual type collapsed it in ~2 minutes.
+- **A triage blamed missing infrastructure it never checked.** A 500 was diagnosed as "missing blob
+  storage" (which would have sent someone to edit already-correct infra) while the real exception
+  sat in the runtime logs the whole time. Pulling the actual stack trace pointed straight at the
+  render code and ended the theory immediately.
+
+Same disease (forward from plausibility), same cure (ground the claim, then try to break it).
+
+## Discipline Rules (ED) checklist
+
+The canonical **Engineering Discipline** rules — the single source of truth every skill cites *by
+ID* (a skill never restates a rule, it cites `ED-1`). Stable IDs are the anti-drift glue, exactly as
+with the Test Rules in [testing.md](testing.md).
+
+| ID | Rule | Applies when |
+|---|---|---|
+| ED-1 | **Grounded claims.** Any factual claim about how the code behaves — what a type/payload contains, what an endpoint returns, what an effect is keyed on, where a value flows — must be traced to an observed source location (`file:line`) before it is written as fact. | Any claim about the system's behavior |
+| ED-2 | **Adversarial self-review.** Before finalizing, treat your *own just-produced* output as a suspect to cross-examine, not a product to defend. Re-trace each asserted data flow / type / contract to source and try to prove it wrong. | Before any spec/ticket/PR is finalized |
+| ED-3 | **Hypothesis vs. conclusion labeling.** A claim that is *not yet* grounded is written as a hypothesis with the evidence needed to settle it ("assumed; evidence needed: pull `X`"), never as established fact. | Whenever a claim can't be grounded *now* |
+| ED-4 | **Scope-fork detection.** Check whether the chosen approach silently changes blast radius or which test tiers apply. Surface the fork explicitly; never let a ticket hide it. | When picking an approach |
+
+## How the rules combine
+
+The adversarial posture (**ED-2**) decides *what* to re-verify; the grounding standard (**ED-1**)
+decides *whether it's actually true*. You need both — they fail together:
+
+- Adversarial without grounding → you challenge a claim but argue from *another* plausible model,
+  and may "correct" a right thing into a wrong one.
+- Grounded without adversarial → you happily verify the claims you bothered to doubt, but never
+  doubt the confident-but-wrong ones. The claims that *feel* obviously right are exactly the class
+  that slips through.
+
+The natural pipeline for a ticket-producing skill: **ground (ED-1) → adversarially attack (ED-2) →
+surface what's still open (ED-3) and any scope fork (ED-4) → escalate genuine forks to the human.**
+This feeds directly into the proactive-contribution step the producer skills run before finalizing a
+ticket (*what we missed / what we should consider / what I'd add*).
+
+## Enforcement and headless behavior
+
+- **Producers** (refine / add-story / prd-to-backlog / triage / reconcile / implement) apply ED-1..ED-4
+  while producing, and label any ungrounded claim per ED-3.
+- **Reviewers** (engineering-review) re-check adversarially: a "checked" criterion or asserted data
+  flow with no backing source is flagged, not trusted.
+- **ED-1 and ED-2 need source access, not a human** — they run **always**, including autonomous /
+  `ORCHESTRATOR_MODE` runs. Only the *escalation of a genuine scope-fork* (ED-4) is gated by mode:
+  headless, default to the **smallest-scope** option **and** record the fork as a flag/follow-up —
+  never silently pick the larger-blast-radius option.
+
+## Relationship to the Test Rules
+
+These rules are general; the Test Rules ([testing.md](testing.md)) are their specific application to
+test design. ED-3's "hypothesis vs. conclusion" guard is the same instinct as a triage root cause
+that must be backed by an actual stack trace; ED-4's scope-fork check is what catches an approach
+that quietly re-introduces a test tier the ticket said didn't apply. Cite the narrower TR rule when
+the context is test design; cite the ED rule for everything else.


### PR DESCRIPTION
Planning doc only — no skill changes yet. This is here so the plan can be reviewed in GitHub before any build starts.

## What this plans
Give the six remaining v4-only skills a v5, and patch `refine-story-v5`:
`add-story-v5`, `prd-to-backlog-v5`, `triage-v5`, `reconcile-backlog-v5`, `conformance-v5`, `security-review-v5` + `refine-story-v5` patch.

## Three disciplines being baked in (all from real misses)
- **Pattern 0 — grounded + adversarial.** Confirm claims against an observed `file:line` (don't guess forward from a plausible model), and falsify your own spec before shipping it as fact (don't rubber-stamp). Motivating example: a current refine-story-v5 spec asserted an `overallGrade` data flow it never traced to the type.
- **Three-part proactive contribution.** Before a ticket is finalized, surface *what we missed / what we should consider / what I'd add* automatically.
- **Evidence-first runtime diagnosis (triage).** For a 5xx/crash, pull the real exception from the dev-env logs before theorizing about infrastructure.

## Locked decisions
- Patch existing v5 skills as the standard evolves (supersedes the original add-only rule).
- Build all at once; order doesn't matter.
- security-review gets a light v5 align.

## Still to confirm (non-blocking, called out in the doc)
- Whether Patterns G + D also extend to `implement-ticket-v5` / `engineering-review-v5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)