### PR TITLE
Fix: Story ID (PREFIX-NNN) missing from ticket descriptions

### DIFF
--- a/skills/add-story-v5/SKILL.md
+++ b/skills/add-story-v5/SKILL.md
@@ -162,6 +162,8 @@ ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
   --title "{Title}" \
   --label "story" \
   --body "$(cat <<'EOF'
+**Story ID:** {PREFIX}-{ISSUE_NUM}
+
 ## Summary
 
 {Description}
@@ -206,9 +208,15 @@ EOF
 
 After creation:
 1. Extract the issue number from the URL: `ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '\d+$')`
-2. Update the title: `gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --title "{PREFIX}-${ISSUE_NUM}: {Title}"`
-3. Set custom fields (Type=Story, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`)
-4. Move to **Up Next**
+2. **Backfill the Story ID + branch into the body** (the body is written before the number exists — keep `{ISSUE_NUM}` as a literal token in the body at creation; this step fills it). This is a mechanical, non-optional step — it's why the Story ID lands every time, not 1-in-4:
+   ```bash
+   gh issue view $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --json body -q .body \
+     | sed "s/{ISSUE_NUM}/${ISSUE_NUM}/g" \
+     | gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --body-file -
+   ```
+3. Update the title: `gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --title "{PREFIX}-${ISSUE_NUM}: {Title}"`
+4. Set custom fields (Type=Story, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`)
+5. Move to **Up Next**
 
 ### 4b. Create Milestone Marker (If Needed)
 
@@ -257,7 +265,7 @@ Tell the user what was created:
 ```
 
 ---
-<!-- skill-version: 5.0 -->
+<!-- skill-version: 5.1 -->
 <!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/skills/prd-to-backlog-v5/SKILL.md
+++ b/skills/prd-to-backlog-v5/SKILL.md
@@ -193,6 +193,10 @@ ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
   --label "foundation" \
   --body "{issue body per story template}")
 ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+# Backfill the Story ID into the body (number didn't exist at create time; keep {ISSUE_NUM} literal in the body)
+gh issue view $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --json body -q .body \
+  | sed "s/{ISSUE_NUM}/${ISSUE_NUM}/g" \
+  | gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --body-file -
 gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --title "{PREFIX}-${ISSUE_NUM}: {Title}"
 ```
 
@@ -207,6 +211,8 @@ ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
   --title "{Title}" \
   --label "story" \
   --body "$(cat <<'EOF'
+**Story ID:** {PREFIX}-{ISSUE_NUM}
+
 ## Summary
 
 {Description — framed from user's perspective}
@@ -249,7 +255,13 @@ EOF
 )"
 ```
 
-After creation, extract the issue number from the URL, update the title to `{PREFIX}-{ISSUE_NUM}: {Title}`, and set custom fields (Type=Story, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`). Move to **Up Next**.
+After creation, extract the issue number from the URL, then **backfill the Story ID into the body** (mechanical, non-optional — keep `{ISSUE_NUM}` literal in the body at creation, this fills it):
+```bash
+gh issue view $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --json body -q .body \
+  | sed "s/{ISSUE_NUM}/${ISSUE_NUM}/g" \
+  | gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --body-file -
+```
+Update the title to `{PREFIX}-{ISSUE_NUM}: {Title}`, set custom fields (Type=Story, Priority, Story ID=`{PREFIX}-{ISSUE_NUM}`), and move to **Up Next**.
 
 ### 3c. Create Milestone Marker Issues
 
@@ -330,7 +342,7 @@ For each milestone, for each story in that milestone:
 ```
 
 ---
-<!-- skill-version: 5.0 -->
+<!-- skill-version: 5.1 -->
 <!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/skills/refine-story-v5/SKILL.md
+++ b/skills/refine-story-v5/SKILL.md
@@ -232,9 +232,11 @@ Plain prose; **no taxonomy buckets** — surface the items directly. The user ca
 
 ### 4a. Compose the Refined Issue Body
 
-Use this template. **Omit sections that don't apply** to the story. Adapt section names to fit the story's domain.
+Use this template. **Omit sections that don't apply** to the story. Adapt section names to fit the story's domain. **Always include the `Story ID` line** — refine has `{STORY_ID}` resolved, so it fills it directly. This is the backstop: even if the creating skill missed it, refine (which runs next) guarantees the Story ID is in the description.
 
 ```markdown
+**Story ID:** {STORY_ID}
+
 ## Summary
 
 [Expanded summary with context pointers]
@@ -411,6 +413,6 @@ OPEN_QUESTIONS: [None | count]
 ```
 
 ---
-<!-- skill-version: 5.1 -->
+<!-- skill-version: 5.2 -->
 <!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->

--- a/skills/triage-v5/SKILL.md
+++ b/skills/triage-v5/SKILL.md
@@ -186,6 +186,8 @@ ISSUE_URL=$(gh issue create --repo {REPO_OWNER}/{REPO_NAME} \
   --title "{Title}" \
   --label "story" \
   --body "$(cat <<'EOF'
+**Story ID:** {PREFIX}-{ISSUE_NUM}
+
 ## Summary
 
 {Description}
@@ -245,7 +247,16 @@ EOF
 )"
 ```
 
-After creation, place the issue on the project board and set all custom fields. Read the project ID, field IDs, and option IDs from `CLAUDE.md` (each project maintains these under "Work Tracking" → "Field IDs" and "Status Options").
+After creation, **backfill the Story ID into the body** (the number didn't exist at create time — keep `{ISSUE_NUM}` literal in the body, this fills it). Mechanical and non-optional:
+
+```bash
+ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+gh issue view $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --json body -q .body \
+  | sed "s/{ISSUE_NUM}/${ISSUE_NUM}/g" \
+  | gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --body-file -
+```
+
+Then place the issue on the project board and set all custom fields. Read the project ID, field IDs, and option IDs from `CLAUDE.md` (each project maintains these under "Work Tracking" → "Field IDs" and "Status Options").
 
 ```bash
 # 1. Add the issue to the project and capture the project item ID
@@ -336,7 +347,7 @@ If the user describes another issue, loop back to **Phase 1**.
 Multi-finding sessions are the norm — a single investigation often surfaces multiple issues. Each gets its own ticket.
 
 ---
-<!-- skill-version: 5.0 -->
+<!-- skill-version: 5.1 -->
 <!-- last-updated: 2026-06-27 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->


### PR DESCRIPTION
## Problem
Tickets are supposed to carry the Story ID (e.g. `HC-474`) in the description, but ~75% of the time it was missing.

## Root cause (grounded in the templates)
None of the body templates had a Story ID line. The ID only ever reached the **title** and the **board custom field** — so it showed up in the description only when the model improvised it (~25%). The mechanism: the issue number doesn't exist until *after* `gh issue create`, and there was no step to backfill the body, so the model was left to "remember" it.

## Fix (mechanical, not "remember to")
Across the four ticket skills:
- **add-story-v5 / prd-to-backlog-v5 / triage-v5** — add `**Story ID:** {PREFIX}-{ISSUE_NUM}` to the body template + a non-optional backfill step that seds the real number into the body right after creation (also fills the `## Branch` placeholder).
- **refine-story-v5** — add the Story ID line filled directly from the already-resolved `{STORY_ID}`, acting as the backstop if creation missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)