### PR TITLE
docs: Phase 6 — bring the workflow/process layer to v5 (complete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ The end-to-end agentic development process (discovery → PRD → backlog → or
 | [workflow/README.md](workflow/README.md) | Workflow overview + per-ticket v5 pipeline at a glance |
 | [workflow/screen-inventory-template.md](workflow/screen-inventory-template.md) | Screen Inventory artifact template (per-surface UI-scope decisions) |
 | [workflow/workflow-diagram.html](workflow/workflow-diagram.html) | Interactive visual diagram of the pipeline |
+| [developer-tools/self-hosted-runner-setup.md](developer-tools/self-hosted-runner-setup.md) | Provision the self-hosted runner that executes the v5 test workflows |
 | [developer-tools/](developer-tools/) | Operator tooling — the dumb loop driver, runner/hooks/VM setup guides |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,22 @@ Shared skills live in `skills/` and are auto-copied to each project's `.claude/s
 | File | Purpose |
 |------|---------|
 | [templates/CLAUDE-project.md](templates/CLAUDE-project.md) | Template CLAUDE.md for new projects — copy and fill in project-specific sections |
+| [templates/workflows/](templates/workflows/) | CI workflow templates (fast / integration / ui tests) — copied into each project's `.github/workflows/` |
+| [templates/scripts/orchestrate.sh](templates/scripts/orchestrate.sh) | Thin orchestration entrypoint wrapper projects vendor as `scripts/orchestrate.sh` |
+
+---
+
+## Process & Workflow
+
+The end-to-end agentic development process (discovery → PRD → backlog → orchestrated pipeline → deploy) and the tooling that runs it:
+
+| Path | Purpose |
+|------|---------|
+| [workflow/agentic-development-workflow.md](workflow/agentic-development-workflow.md) | Master process doc — all phases, the v5 pipeline, mode-switching orchestrator, four-tier testing |
+| [workflow/README.md](workflow/README.md) | Workflow overview + per-ticket v5 pipeline at a glance |
+| [workflow/screen-inventory-template.md](workflow/screen-inventory-template.md) | Screen Inventory artifact template (per-surface UI-scope decisions) |
+| [workflow/workflow-diagram.html](workflow/workflow-diagram.html) | Interactive visual diagram of the pipeline |
+| [developer-tools/](developer-tools/) | Operator tooling — the dumb loop driver, runner/hooks/VM setup guides |
 
 ---
 

--- a/developer-tools/self-hosted-runner-setup.md
+++ b/developer-tools/self-hosted-runner-setup.md
@@ -1,0 +1,146 @@
+# Self-Hosted Runner Setup (v5 CI)
+
+The v5 test workflows (`templates/workflows/{fast,integration,ui}-tests.yml`) all declare
+`runs-on: self-hosted`. They need a **persistent** machine because the integration and UI tiers
+run real infrastructure: Testcontainers (real SQL Server) and a full Docker Compose stack with a
+Playwright browser. GitHub-hosted runners can't keep that warm or give reliable Docker-in-Docker,
+so each project that adopts v5 points its repo at one self-hosted runner.
+
+This guide sets up a single Linux/WSL2 runner, installed **as a service** so it survives reboots,
+with Docker access for the integration/UI tiers. It assumes the standard GitHub Actions runner
+(`actions/runner`).
+
+## Quick reference
+
+```bash
+# Status / control once installed (run from the runner dir)
+sudo ./svc.sh status
+sudo ./svc.sh start
+sudo ./svc.sh stop
+
+# Smoke-test the runner path end to end (dispatch from the repo)
+gh workflow run ui-tests.yml --ref <branch> -f filter="FullyQualifiedName~SmokeTests"
+```
+
+## What the runner must provide
+
+| Tier | Workflow | Needs Docker? | Other |
+|------|----------|---------------|-------|
+| Unit + Contract (fast) | `fast-tests.yml` | **No** — `DOCKER_HOST` is set to an unreachable address on purpose (TR-11). Don't "fix" it. | .NET SDK |
+| Integration | `integration-tests.yml` | **Yes** — Testcontainers spins up real SQL Server | .NET SDK |
+| UI | `ui-tests.yml` (`workflow_dispatch`) | **Yes** — `docker compose ... up` the app + Playwright stack | .NET SDK, the compose files on the branch, ports `5001` (API health) / `5002` (client) per project |
+
+So the host needs: the **.NET SDK** matching the project's `global.json`/TFM, a working **Docker
+daemon** the runner user can reach, and enough disk for images + Testcontainers volumes.
+
+## 1. Prerequisites (one-time on the host)
+
+```bash
+# .NET SDK — match the project's target (example: .NET 9)
+# (use the project's documented install; on Ubuntu/WSL2 the dotnet-install script is simplest)
+dotnet --info
+
+# Docker — daemon must be running and usable WITHOUT sudo by the runner user
+docker run --rm hello-world          # must succeed as the runner user
+sudo usermod -aG docker "$USER"      # then log out/in (or `newgrp docker`) if it needed sudo
+```
+
+On **WSL2**, either use Docker Desktop with WSL integration enabled for the distro, or run native
+`dockerd` inside the distro. Verify `docker run --rm hello-world` works **as the runner user**, not
+just under `sudo` — the runner service won't have your interactive sudo.
+
+## 2. Register the runner
+
+1. In the repo on GitHub: **Settings → Actions → Runners → New self-hosted runner → Linux**. GitHub
+   shows a download block and a **registration token** (short-lived).
+2. On the host:
+
+```bash
+mkdir -p ~/actions-runner && cd ~/actions-runner
+# Use the download URL/version GitHub shows on that page:
+curl -o actions-runner-linux-x64.tar.gz -L \
+  https://github.com/actions/runner/releases/download/v<VERSION>/actions-runner-linux-x64-<VERSION>.tar.gz
+tar xzf actions-runner-linux-x64.tar.gz
+
+# Configure against the repo with the token from the page. Keep the default 'self-hosted' label
+# (the workflows match on it). Add project-specific labels only if you later run multiple runners.
+./config.sh --url https://github.com/<OWNER>/<REPO> --token <REGISTRATION_TOKEN>
+```
+
+Accept the defaults for runner group, name, and work folder unless you have a reason not to.
+
+## 3. Install as a service (survives reboot)
+
+Running `./run.sh` interactively dies when the shell closes — install the service instead:
+
+```bash
+sudo ./svc.sh install        # registers a systemd service for the current user
+sudo ./svc.sh start
+sudo ./svc.sh status         # should show 'active (running)' and 'Connected to GitHub'
+```
+
+### WSL2: keep it alive across reboots
+
+WSL2 shuts the distro down when nothing is running and does not auto-start on Windows boot. To keep
+the runner up:
+
+1. **Enable systemd in the distro** so `svc.sh` (systemd) works — in `/etc/wsl.conf`:
+   ```ini
+   [boot]
+   systemd=true
+   ```
+   then `wsl --shutdown` from Windows and reopen the distro.
+2. **Auto-start the distro on Windows login** — a Task Scheduler task running
+   `wsl -d <Distro> -u root -e /bin/true` (or `wsl.exe --exec dbus-launch true`) at logon is enough
+   to boot the distro; systemd then brings the runner service up.
+
+Confirm after a reboot: `sudo ./svc.sh status` shows running and the runner shows **Idle** (green)
+on the GitHub Runners page.
+
+## 4. Smoke-test the runner path
+
+Reproduce the path the pilot proved — echo, then Docker, then a real test run:
+
+```bash
+# 1. Does the runner pick up jobs at all? Dispatch the UI workflow with a trivial filter:
+gh workflow run ui-tests.yml --ref <branch> -f filter="FullyQualifiedName~SmokeTests"
+gh run watch   # or watch the Actions tab
+
+# 2. Docker reachable from a job? The integration workflow exercising Testcontainers is the real test:
+gh workflow run integration-tests.yml --ref <branch>
+```
+
+If the fast tier passes but integration/UI can't reach Docker, the runner **user** lacks Docker
+access (see Prerequisites) — the fast tier doesn't expose it because `DOCKER_HOST` is deliberately
+unreachable there.
+
+## 5. Persistent-runner hygiene
+
+A long-lived runner accumulates state; budget for it:
+
+- **Disk** — Testcontainers images, compose stacks, and the runner's `_work` dir grow. Prune
+  periodically: `docker system prune -af --volumes` (when no run is active) and clear stale
+  `_work/<repo>` checkouts.
+- **Leftover containers** — a crashed UI run can leave the compose stack up. The `ui-tests.yml`
+  teardown handles the happy path; after a failure, `docker compose ... down` manually (or a
+  scheduled `docker container prune`).
+- **Toolchain drift** — when a project bumps its .NET TFM or Playwright version, update the SDK and
+  run `pwsh playwright.ps1 install --with-deps` (or the project's documented browser install) on the
+  host. The runner does **not** auto-provision toolchains.
+- **Runner updates** — the service auto-updates the runner agent in most cases; if it falls behind,
+  `sudo ./svc.sh stop && ./config.sh remove --token <TOKEN>` then re-register with a fresh token.
+- **One runner, multiple repos** — register a separate runner per repo (separate `actions-runner`
+  dirs), or use a runner group. Don't share one `_work` dir across repos.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Jobs queue forever, runner shows **Offline** | Service not running / distro shut down | `sudo ./svc.sh start`; on WSL2 confirm systemd + auto-start (§3) |
+| Integration/UI jobs fail on `docker` | Runner user can't reach the daemon | Add user to `docker` group; verify `docker run --rm hello-world` as that user |
+| Fast tier fails trying to use Docker | A Testcontainers/Docker reference leaked into a fast-tier project (TR-11) | Move that test to the integration tier — do **not** point `DOCKER_HOST` at the real daemon |
+| UI run checks out the wrong code | `ref` input defaulting to `main` | Pass `--ref <branch>` (and `-f ref=<branch>` for clarity) — see `templates/workflows/README.md` |
+| Runner dies when terminal closes | Started with `./run.sh` instead of the service | `sudo ./svc.sh install && sudo ./svc.sh start` |
+
+See also: [templates/workflows/README.md](../templates/workflows/README.md) (the workflows this runner
+executes) and [standards/testing.md](../standards/testing.md) (the four-tier model and CI trigger rules).

--- a/notes/v5-implementation-plan.md
+++ b/notes/v5-implementation-plan.md
@@ -80,10 +80,14 @@ back into the standards repo along the way:
 - **Story ID in the ticket body** (PR #6, merged): the four ticket skills now put `{PREFIX}-{NNN}` in
   the description with a mechanical post-create backfill (was missing ~75% of the time).
 
-**Next action: Phase 6 — process documentation** (the final standards-repo phase). The workflow/process
-layer is still v4-coded and now actively contradicts what shipped. Phase 6 must also fold in the
-round-out (ED discipline, the six authoring/audit skills, the contribution step) — these post-date this
-plan's original Phase 6 list below.
+**Phase 6 — COMPLETE (2026-06-27)** (PR #7). The workflow/process layer rewritten to v5: master doc +
+README (mode-switching orchestrator, four-tier testing, UI on the runner, ED + contribution), screen
+inventory (per-surface UI scope), the hand-built HTML diagram redrawn (WORKING/CLEANUP, relaunch loop,
+CI watcher, CLEANUP box), a new self-hosted-runner setup guide in `developer-tools/`, and `CLAUDE.md`
+now indexes the workflow/process/templates layer. `templates/CLAUDE-project.md` was already v5-aligned.
+
+**All six phases of the v5 implementation plan are now complete.** Remaining optional follow-up:
+archive the v4 skills once you're ready (deferred by choice — see Cross-cutting).
 
 **Already done:** #9 UI-test anti-patterns are live in `standards/testing.md` (commit `de70473`).
 **Deferred (do NOT build):** #4 mutation testing (paydown only); the concurrent overseer (upgrade to #6).
@@ -347,20 +351,20 @@ was planned. Apply **G1** (copy-to-`-v5` vs. edit in place) per artifact.
   **self-hosted runner** execution (#8), the **mode-switching orchestrator + dumb loop** (#6, replaces
   the v4 supervisor/worker description), and the **TR checklist** dual sign-off (#10). Remove
   "Playwright gates every PR" and Docker-required-locally framing.
-- [ ] **6.2 — `workflow/workflow-diagram.html`**: regenerate for the v5 pipeline (currently labeled
+- [x] **6.2 — `workflow/workflow-diagram.html`**: regenerate for the v5 pipeline (currently labeled
   "v4 pipeline"). **Note:** hand-built HTML — regeneration is real work, not a tweak. G1 call:
   new `workflow-diagram-v5.html` vs. edit in place.
 - [x] **6.3 — `workflow/README.md`**: update the stage list, drop the "v4 pipeline" labels, point at
   the v5 diagram, refresh `-v4`→`-v5` skill names.
 - [x] **6.4 — `workflow/screen-inventory-template.md`**: add the **per-surface UI-scope decision**
   (#3 / TR-5) — record per surface whether it's in/out of UI-tier scope.
-- [~] **6.5 — `templates/CLAUDE-project.md` + the project entrypoint wrapper:** update test-run
+- [x] **6.5 — `templates/CLAUDE-project.md` + the project entrypoint wrapper:** update test-run
   patterns to the four tiers + trigger model; add the Contract tier; reference the TR checklist;
   refresh skill names per G1. **Also ship the thin driver wrapper** — a `templates/scripts/orchestrate.sh`
   (~3 lines: `git -C ../TI-Engineering-Standards pull --ff-only` → exec `developer-tools/orchestrate-loop.sh`
   with `--project-dir "$(pwd)"`) that projects vendor as `scripts/orchestrate.sh`, plus a documented
   one-command flow in the template CLAUDE.md: `git clone <project>` → `git pull` → `./scripts/orchestrate.sh`.
-- [ ] **6.6 — `developer-tools/`**: document the **self-hosted runner** setup (#8 — install-as-service,
+- [x] **6.6 — `developer-tools/`**: document the **self-hosted runner** setup (#8 — install-as-service,
   WSL2/Linux, Docker access, persistent-runner hygiene) — likely a new doc alongside the existing
   hooks/VM-scripts.
 - [x] **6.7 — Index `workflow/` in `CLAUDE.md`** — the folder is currently **not referenced** in the

--- a/notes/v5-implementation-plan.md
+++ b/notes/v5-implementation-plan.md
@@ -69,11 +69,21 @@ close-issue for run-complete. `project-tracking.md` got the Orchestration Run Tr
 **v5 MERGED TO `main` 2026-06-21** (merge commit `763514c`, pushed). Phases 0–4 are live; v5 is the
 standard. v4 skills retained (pin per project via `-v4`/`-v5` skill name). `v5-build` kept as history.
 
-**Next action: Phase 5 — pilot on HeyCAPTO** (user-owned, separate instance; runner already set up).
-Single-ticket smoke first, then a 3–5 ticket run. v5 is on `main`, so HeyCAPTO's auto-sync picks it up
-normally. User actuates there (fill workflow templates, confirm CLAUDE.md names the four test projects,
-one ticket in Up Next, `orchestrate-v5 supervised #<issue>`); reports mismatches back to tune before the
-3–5 run. Then Phase 6 (process docs/diagram/templates) is the final standards-repo phase.
+**Phase 5 — COMPLETE (2026-06-27).** Piloted on HeyCAPTO: shipped a substantial amount of software
+through the v5 pipeline, captured lessons, and iterated several times. Two notable iterations folded
+back into the standards repo along the way:
+- **The v5 round-out** (PR #5, merged): `standards/engineering-discipline.md` (ED-1..ED-4 — grounded +
+  adversarial), the six remaining authoring/audit skills brought to v5 (`add-story`, `prd-to-backlog`,
+  `reconcile-backlog`, `triage`, `conformance`, `security-review`), the three-part contribution step,
+  evidence-first runtime diagnosis in triage, and ED patches to refine/implement/engineering-review.
+  Tracked in [v5-round-out-plan.md](v5-round-out-plan.md).
+- **Story ID in the ticket body** (PR #6, merged): the four ticket skills now put `{PREFIX}-{NNN}` in
+  the description with a mechanical post-create backfill (was missing ~75% of the time).
+
+**Next action: Phase 6 — process documentation** (the final standards-repo phase). The workflow/process
+layer is still v4-coded and now actively contradicts what shipped. Phase 6 must also fold in the
+round-out (ED discipline, the six authoring/audit skills, the contribution step) — these post-date this
+plan's original Phase 6 list below.
 
 **Already done:** #9 UI-test anti-patterns are live in `standards/testing.md` (commit `de70473`).
 **Deferred (do NOT build):** #4 mutation testing (paydown only); the concurrent overseer (upgrade to #6).
@@ -310,20 +320,17 @@ Apply G1 (copy vs. edit). Each skill cites `standards/testing.md` rather than re
 
 ---
 
-## Phase 5 — Pilot & validate
+## Phase 5 — Pilot & validate  *(COMPLETE 2026-06-27)*
 
-- [ ] **5.0 — Per-repo actuation of the Phase 2 substrate** (the half that can't live in the standards
-  repo): on the pilot repo, **instantiate** the template workflows into `.github/workflows/` (fill in
-  project name + test-project paths), **run the branch-protection script** (2.3), **install the
-  self-hosted runner** (2.5/6.6 guide — as a service, WSL2), and **self-test the runner path**:
-  dispatch a workflow `echo` → `docker run --rm hello-world` → a real `dotnet test` (the path already
-  proven 2026-06-18).
-- [ ] **5.1 —** Run v5 end-to-end on the pilot repo with a small batch (3–5 tickets).
-- [ ] **5.2 — Verify:** fast/PR + integration/pre-merge gates fire; tier boundaries enforced; UI runs
-  on the runner (scoped per-story + full at boundary); loop chunks at N and relaunches; CLEANUP fires
-  ratio/drift/gate-audit; crash recovery works.
-- [ ] **5.3 — Tune N** to the observed reliability threshold.
-- [ ] **5.4 —** Capture lessons; only then consider rolling v5 to other repos.
+- [x] **5.0 — Per-repo actuation of the Phase 2 substrate** — done on HeyCAPTO (workflows instantiated,
+  branch protection, self-hosted runner installed and self-tested).
+- [x] **5.1 —** Ran v5 end-to-end on HeyCAPTO across a substantial batch of real tickets (well beyond 3–5).
+- [x] **5.2 — Verified** in practice: gates fire, tier boundaries hold, UI runs on the runner, the loop
+  chunks/relaunches, CLEANUP fires, crash recovery works.
+- [x] **5.3 — Tuned N** against observed reliability.
+- [x] **5.4 — Lessons captured and folded back**: the v5 round-out (PR #5) and the Story ID fix (PR #6).
+  v5 is proven; rolling to other repos is unblocked. (v4-skill archival still deferred per earlier call —
+  see Cross-cutting.)
 
 ---
 
@@ -334,7 +341,7 @@ will **directly contradict** the new model until updated (e.g. the master doc st
 runs in CI on every PR"). Sequenced **after Phase 5** so docs describe what actually shipped, not what
 was planned. Apply **G1** (copy-to-`-v5` vs. edit in place) per artifact.
 
-- [ ] **6.1 — `workflow/agentic-development-workflow.md`** (master process doc): rewrite to the v5
+- [x] **6.1 — `workflow/agentic-development-workflow.md`** (master process doc): rewrite to the v5
   model — four-tier testing (Unit/Contract/Integration/UI), the **trigger model** (fast/PR,
   integration/required-pre-merge, UI at orchestration boundary via `workflow_dispatch`),
   **self-hosted runner** execution (#8), the **mode-switching orchestrator + dumb loop** (#6, replaces
@@ -343,11 +350,11 @@ was planned. Apply **G1** (copy-to-`-v5` vs. edit in place) per artifact.
 - [ ] **6.2 — `workflow/workflow-diagram.html`**: regenerate for the v5 pipeline (currently labeled
   "v4 pipeline"). **Note:** hand-built HTML — regeneration is real work, not a tweak. G1 call:
   new `workflow-diagram-v5.html` vs. edit in place.
-- [ ] **6.3 — `workflow/README.md`**: update the stage list, drop the "v4 pipeline" labels, point at
+- [x] **6.3 — `workflow/README.md`**: update the stage list, drop the "v4 pipeline" labels, point at
   the v5 diagram, refresh `-v4`→`-v5` skill names.
-- [ ] **6.4 — `workflow/screen-inventory-template.md`**: add the **per-surface UI-scope decision**
+- [x] **6.4 — `workflow/screen-inventory-template.md`**: add the **per-surface UI-scope decision**
   (#3 / TR-5) — record per surface whether it's in/out of UI-tier scope.
-- [ ] **6.5 — `templates/CLAUDE-project.md` + the project entrypoint wrapper:** update test-run
+- [~] **6.5 — `templates/CLAUDE-project.md` + the project entrypoint wrapper:** update test-run
   patterns to the four tiers + trigger model; add the Contract tier; reference the TR checklist;
   refresh skill names per G1. **Also ship the thin driver wrapper** — a `templates/scripts/orchestrate.sh`
   (~3 lines: `git -C ../TI-Engineering-Standards pull --ff-only` → exec `developer-tools/orchestrate-loop.sh`
@@ -356,7 +363,7 @@ was planned. Apply **G1** (copy-to-`-v5` vs. edit in place) per artifact.
 - [ ] **6.6 — `developer-tools/`**: document the **self-hosted runner** setup (#8 — install-as-service,
   WSL2/Linux, Docker access, persistent-runner hygiene) — likely a new doc alongside the existing
   hooks/VM-scripts.
-- [ ] **6.7 — Index `workflow/` in `CLAUDE.md`** — the folder is currently **not referenced** in the
+- [x] **6.7 — Index `workflow/` in `CLAUDE.md`** — the folder is currently **not referenced** in the
   standards index, which is exactly why it's easy to forget. Add it (and `templates/`,
   `developer-tools/` if not present).
 - [ ] **Deliverable:** v5 process docs + diagram + templates; `CLAUDE.md` indexes the workflow layer.

--- a/templates/workflows/README.md
+++ b/templates/workflows/README.md
@@ -3,7 +3,9 @@
 Parameterized GitHub Actions workflows that implement the v5 trigger model
 (`standards/testing.md` → CI/CD Testing Tiers). They are **repo-agnostic templates** —
 the standards repo ships them, each project instantiates them once. All three run on a
-**self-hosted runner** (`runs-on: self-hosted`).
+**self-hosted runner** (`runs-on: self-hosted`) — see
+[developer-tools/self-hosted-runner-setup.md](../../developer-tools/self-hosted-runner-setup.md)
+to provision one.
 
 | Workflow | Tier | Trigger | Gates merge? |
 |----------|------|---------|--------------|

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,13 +1,13 @@
 # Agentic Development Workflow
 
-This folder contains the end-to-end workflow for 100% agentic software development using Claude, GitHub Projects, and a PR-based supervisor/worker orchestration pattern with review gates and milestones.
+This folder contains the end-to-end workflow for 100% agentic software development using Claude, GitHub Projects, and a **mode-switching orchestrator** (relaunched by a dumb loop) running a PR-based pipeline with review gates and milestones.
 
 ## Contents
 
 | File | Description |
 |------|-------------|
 | [agentic-development-workflow.md](agentic-development-workflow.md) | Full written guide covering all phases from discovery through deployment |
-| [workflow-diagram.html](workflow-diagram.html) | Interactive visual diagram of the v4 pipeline |
+| [workflow-diagram.html](workflow-diagram.html) | Interactive visual diagram of the pipeline |
 | [screen-inventory-template.md](screen-inventory-template.md) | Reusable template for the Screen Inventory artifact (Phase 2) |
 
 ## Workflow Diagram
@@ -18,29 +18,37 @@ This folder contains the end-to-end workflow for 100% agentic software developme
 
 1. **Discovery & Capture** — Record freeform discussions with Otter.ai
 2. **PRD Refinement** — Claude Web synthesizes transcript into PRD, Screen Inventory, and Decisions Log
-3. **Project Bootstrap** — Claude Code creates repo, board, and milestoned backlog (prd-to-backlog-v4)
-4. **Orchestrated Development** — PR-based pipeline: Refine → Implement → Engineering Review → Security Review → Integration Tests → Review → UI Tests → Review → Merge (orchestrate-v4)
+3. **Project Bootstrap** — Claude Code creates repo, board, and milestoned backlog (`prd-to-backlog-v5`)
+4. **Orchestrated Development** — PR-based pipeline: Refine → Implement → Engineering Review → Security Review → Integration Tests → Review → UI Tests → Review → Merge, driven by `orchestrate-v5`
 5. **Session Summary & Review** — Observability metrics, PRD amendments, debug and iterate
 6. **Deployment & Promotion** — Dev auto-deploy, manual promotion to Staging and Production
 7. **Ongoing Project Health** — Standards re-sync, conformance checks, dependency updates
 
-## v4 Pipeline Per Ticket
+## v5 Pipeline Per Ticket
+
+The four-tier test model (Unit / Contract / Integration / UI) governs what runs where. Unit + Contract are the **fast tier** (no Docker); Integration uses real infra; **UI runs on the self-hosted runner via `workflow_dispatch`, scoped per story — not a blocking gate on every PR.** Each producer stage signs off its TR rows; the reviewer re-checks them adversarially. See [standards/testing.md](../standards/testing.md).
 
 ```
-1.   REFINE ──────────── refine-story-v4
-2.   IMPLEMENT ───────── implement-ticket-v4 → PR #1
-3.   ENGINEERING REVIEW ─ engineering-review-v4 (↻ max 3 fix iterations)
-3.5. SECURITY REVIEW ──── security-review-v4 (OWASP + infra, ↻ max 2 fix iterations) → merge PR #1
-4.   INTEGRATION TESTS ── integration-test-v4 → PR #2
-5.   ENGINEERING REVIEW ─ engineering-review-v4 (↻ max 3 fix iterations) → merge PR #2
-6.   UI TESTS ─────────── ui-test-v4 → PR #3
-7.   ENGINEERING REVIEW ─ engineering-review-v4 (↻ max 3 fix iterations) → merge PR #3
-8.   CLOSE ───────────── acceptance criteria → close issue
+1.   REFINE ──────────── refine-story-v5 (behavior-first tier table; adversarial self-review)
+2.   IMPLEMENT ───────── implement-ticket-v5 → PR #1 (Unit + Contract tests)
+3.   ENGINEERING REVIEW ─ engineering-review-v5 (↻ max 3 fix iterations)
+3.5. SECURITY REVIEW ──── security-review-v5 (OWASP Top 10 + infrastructure) → merge PR #1
+4.   INTEGRATION TESTS ── integration-test-v5 → PR #2 (real-infra behavior only)
+5.   ENGINEERING REVIEW ─ engineering-review-v5 (↻ max 3 fix iterations) → merge PR #2
+6.   UI TESTS ─────────── ui-test-v5 → PR #3 (journey-scoped, runner via workflow_dispatch)
+7.   ENGINEERING REVIEW ─ engineering-review-v5 (↻ max 3 fix iterations) → merge PR #3
+8.   CLOSE ───────────── acceptance criteria → close issue (orchestrator owns the close)
      ⬥ MILESTONE GATE ── hard stop, smoke test, human approval
 ```
 
+The orchestrator is **stateless and relaunched** by the dumb loop: it self-selects **WORKING** (process up to N ready tickets) or **CLEANUP** (end-of-run oversight) from durable state on a per-run tracking issue, so it survives crashes and avoids context rot. CI failures are repaired in the background by `ci-fix-v5` after each merge; `monitor-v5` narrates the run read-only.
+
+## Working discipline
+
+Every skill works under [standards/engineering-discipline.md](../standards/engineering-discipline.md) (ED-1..ED-4): confirm claims against source, adversarially self-review before finalizing. The ticket-producing skills end with a three-part contribution (*what we missed / should consider / I'd add*).
+
 ## Related
 
-- [Skills](../skills/) — The v4 Claude Code skills that power Phases 3-5
-- [Standards](../standards/) — Engineering standards including story-writing-standards.md
-- [Templates](../templates/) — Project CLAUDE.md template and issue templates
+- [Skills](../skills/) — The v5 Claude Code skills that power Phases 3–5
+- [Standards](../standards/) — Engineering standards including `testing.md`, `engineering-discipline.md`, and `story-writing-standards.md`
+- [Templates](../templates/) — Project CLAUDE.md template, CI workflow templates, and the orchestrate.sh wrapper

--- a/workflow/agentic-development-workflow.md
+++ b/workflow/agentic-development-workflow.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the end-to-end workflow for 100% agentic software development using Claude (web interface and Claude Code), GitHub Projects, and a supervisor/worker orchestration pattern with PR-based review gates. The workflow covers everything from initial brainstorming through deployed, tested, reviewed code.
+This document defines the end-to-end workflow for 100% agentic software development using Claude (web interface and Claude Code), GitHub Projects, and a **mode-switching orchestrator** (`orchestrate-v5`, relaunched by a dumb loop) running a PR-based pipeline with review gates. The workflow covers everything from initial brainstorming through deployed, tested, reviewed code. Every skill works under [engineering-discipline.md](../standards/engineering-discipline.md) (ED-1..ED-4: confirm against source, adversarially self-review).
 
 The core philosophy: separate concerns between human-driven discovery, AI-assisted specification, and fully orchestrated development — with clean context boundaries at each transition to prevent drift, and milestone-based review gates to ensure human validation at meaningful intervals.
 
@@ -112,9 +112,9 @@ The project pulls from the shared TI-Engineering-Standards repository. On sessio
 
 This is defined in each project's `CLAUDE.md` using the project template at `templates/CLAUDE-project.md`.
 
-### 3.3 Backlog Generation (prd-to-backlog-v4)
+### 3.3 Backlog Generation (prd-to-backlog-v5)
 
-Use the `prd-to-backlog-v4` skill to decompose the PRD into a milestoned backlog. The skill:
+Use the `prd-to-backlog-v5` skill to decompose the PRD into a milestoned backlog. The skill:
 
 1. Reads the PRD, Screen Inventory, Decisions Log, and ARCHITECTURE.md
 2. Identifies foundation work (kept minimal — only what can't be part of a vertical slice)
@@ -134,9 +134,9 @@ After the skill generates stories, review them:
 - Are there gaps — PRD requirements with no corresponding story?
 - Are milestone groupings sensible?
 
-### 3.5 Incremental Story Additions (add-story-v4)
+### 3.5 Incremental Story Additions (add-story-v5)
 
-When adding stories mid-project (not during initial PRD decomposition), use `add-story-v4`. The skill:
+When adding stories mid-project (not during initial PRD decomposition), use `add-story-v5`. The skill:
 
 1. Reviews the existing backlog and codebase
 2. Works conversationally to understand what you want to add
@@ -144,16 +144,16 @@ When adding stories mid-project (not during initial PRD decomposition), use `add
 4. Determines milestone placement
 5. Creates issues after human approval
 
-### 3.6 PRD Reconciliation (reconcile-backlog-v4)
+### 3.6 PRD Reconciliation (reconcile-backlog-v5)
 
-When a PRD is revised mid-project (scope changes, new decisions, stakeholder feedback), use `reconcile-backlog-v4` to reconcile the changes against the existing backlog and codebase. The skill:
+When a PRD is revised mid-project (scope changes, new decisions, stakeholder feedback), use `reconcile-backlog-v5` to reconcile the changes against the existing backlog and codebase. The skill:
 
 1. Diffs the old and new PRDs section by section, identifying material changes
 2. Fetches the full backlog (open and closed issues) and scans the codebase to understand what's already built
 3. Classifies each change as: **CREATE** (new ticket), **UPDATE** (modify existing open ticket), **FLAG** (closed ticket needs rework — creates a delta ticket), or **SKIP** (cosmetic/doc-only)
 4. Writes a checklist file to `docs/` for state tracking and recovery
 5. Presents the full reconciliation plan for human approval before touching GitHub
-6. Executes approved actions using `add-story-v4` (for new tickets) and `refine-story-v4` (to re-refine updated tickets)
+6. Executes approved actions using `add-story-v5` (for new tickets) and `refine-story-v5` (to re-refine updated tickets)
 
 This keeps the backlog in sync with the PRD as a living document, rather than requiring a full re-decomposition.
 
@@ -181,39 +181,39 @@ If any tests fail on a fresh clone, stop and fix before proceeding. A clean base
 
 ## Phase 4: Orchestrated Development
 
-**Tool:** Claude Code with orchestrate-v4
+**Tool:** Claude Code with orchestrate-v5
 **Input:** Backlog tickets (refined automatically by the orchestrator as Stage 1)
 **Output:** Implemented, reviewed, tested, merged code
 
 ### 4.1 Architecture: PR-Based Pipeline with Review Gates
 
-The v4 pipeline uses pull requests as the unit of work with automated engineering and security review gates. The orchestrator spawns fresh sub-agents for each stage, preventing context drift.
+The v5 pipeline uses pull requests as the unit of work with automated engineering and security review gates. The orchestrator spawns fresh sub-agents for each stage, preventing context drift. It is itself **stateless and relaunched** by a dumb loop: on each launch it self-selects **WORKING** (process up to N ready tickets, then checkpoint and exit) or **CLEANUP** (end-of-run oversight) from durable state on a per-run tracking issue — so a crash mid-run just relaunches and recovers state, and no single session accumulates context rot. The test work follows the four-tier model (Unit + Contract = fast tier, no Docker; Integration = real infra; UI = journey-scoped on the self-hosted runner); see [standards/testing.md](../standards/testing.md).
 
 ```
 Per Ticket:
-1.  REFINE ──────────── refine-story-v4 (enriches issue spec)
-2.  IMPLEMENT ───────── implement-ticket-v4 (creates PR #1)
-3.  ENGINEERING REVIEW ─ engineering-review-v4 (standards check)
+1.  REFINE ──────────── refine-story-v5 (enriches issue spec)
+2.  IMPLEMENT ───────── implement-ticket-v5 (creates PR #1)
+3.  ENGINEERING REVIEW ─ engineering-review-v5 (standards check)
     └─ Loop: reviewer ↔ implementer fix mode (max 3 iterations)
-4.  SECURITY REVIEW ──── security-review-v4 (OWASP Top 10 + infrastructure)
+4.  SECURITY REVIEW ──── security-review-v5 (OWASP Top 10 + infrastructure)
     └─ Loop: reviewer ↔ implementer fix mode (max 2 iterations)
     └─ On pass → merge PR #1
-    └─ ci-fix-v4 WATCH (background) ─── monitors CI/CD for the merge
-5.  INTEGRATION TESTS ── integration-test-v4 (creates PR #2)
-6.  ENGINEERING REVIEW ─ engineering-review-v4 (integration test quality)
+    └─ ci-fix-v5 WATCH (background) ─── monitors CI/CD for the merge
+5.  INTEGRATION TESTS ── integration-test-v5 (creates PR #2)
+6.  ENGINEERING REVIEW ─ engineering-review-v5 (integration test quality)
     └─ Loop: reviewer ↔ test-writer fix mode (max 3 iterations)
     └─ On approve → merge PR #2
-    └─ ci-fix-v4 WATCH (background) ─── monitors CI/CD for the merge
-7.  UI TESTS ─── ui-test-v4 (creates PR #3)
-8.  ENGINEERING REVIEW ─ engineering-review-v4 (ui test quality)
+    └─ ci-fix-v5 WATCH (background) ─── monitors CI/CD for the merge
+7.  UI TESTS ─── ui-test-v5 (creates PR #3)
+8.  ENGINEERING REVIEW ─ engineering-review-v5 (ui test quality)
     └─ Loop: reviewer ↔ test-writer fix mode (max 3 iterations)
     └─ On approve → merge PR #3
-    └─ ci-fix-v4 WATCH (background) ─── monitors CI/CD for the merge
+    └─ ci-fix-v5 WATCH (background) ─── monitors CI/CD for the merge
 9.  CLOSE ───────────── drain CI watchers, check acceptance criteria, close issue
 
     Background CI/CD side-channel:
-    ┌─ ci-fix-v4 WATCH reports failure
-    └─ ci-fix-v4 FIX (background) ─── diagnoses logs, creates fix PR, merges
+    ┌─ ci-fix-v5 WATCH reports failure
+    └─ ci-fix-v5 FIX (background) ─── diagnoses logs, creates fix PR, merges
        └─ If FIX blocked → circuit breaker halts orchestrator
 ```
 
@@ -229,8 +229,13 @@ This ensures the developer can launch the application, interact with it, and ver
 
 ### 4.3 Operating Modes
 
-- **Supervised**: hard stop between each ticket. Used when iterating on skills, early in a project, or when close oversight is desired.
-- **Autonomous**: continues between tickets automatically, stopping only at milestones, circuit breakers, or completion.
+The orchestrator self-selects a **run mode** from durable state on each relaunch:
+- **WORKING**: tickets are in "Up Next" — process up to N of them, checkpoint to the tracking issue, and exit (the loop relaunches it).
+- **CLEANUP**: nothing left in "Up Next" — run end-of-batch oversight (full UI dispatch, pyramid-ratio + drift check, TR gate-audit, inject fixes), then close the run.
+
+Orthogonally, a **human-oversight mode** controls cadence:
+- **Supervised**: hard stop between each ticket (`orchestrate-v5 supervised #<issue>`). Used when iterating on skills, early in a project, or when close oversight is desired.
+- **Autonomous**: the dumb loop relaunches the orchestrator continuously, stopping only at milestones, circuit breakers, or completion. An operator can steer a headless run between loops via the operator-message slot on the tracking issue.
 
 ### 4.4 Circuit Breakers
 
@@ -244,15 +249,15 @@ Even in autonomous mode, the orchestrator halts entirely if:
 
 ### 4.5 Background CI/CD Health Watching
 
-After every PR merge, the orchestrator spawns **ci-fix-v4** in WATCH mode as a background agent. This runs in parallel with the next pipeline stage — the orchestrator does not block on it.
+After every PR merge, the orchestrator spawns **ci-fix-v5** in WATCH mode as a background agent. This runs in parallel with the next pipeline stage — the orchestrator does not block on it.
 
 - **If CI/CD passes:** The watcher reports success and the orchestrator logs it. No action needed.
-- **If CI/CD fails:** The watcher reports the failure. The orchestrator spawns **ci-fix-v4** in FIX mode — also in the background. The fix agent downloads failure logs, diagnoses the root cause, creates a fix branch, pushes a repair PR, and merges it. All of this happens on its own branch, parallel to whatever ticket is currently in progress.
+- **If CI/CD fails:** The watcher reports the failure. The orchestrator spawns **ci-fix-v5** in FIX mode — also in the background. The fix agent downloads failure logs, diagnoses the root cause, creates a fix branch, pushes a repair PR, and merges it. All of this happens on its own branch, parallel to whatever ticket is currently in progress.
 - **If the fix cannot be applied:** The fix agent reports Blocked, which triggers a circuit breaker — the orchestrator halts after the current stage completes.
 
 This eliminates the blind spot where CI/CD breaks silently and multiple tickets pile up without deploying. The orchestrator discovers failures within minutes of the merge that caused them, and in most cases fixes them automatically without interrupting the current ticket's pipeline.
 
-The ci-fix-v4 skill can also be invoked standalone (`/ci-fix-v4`) to diagnose and repair CI/CD issues outside of the orchestrator pipeline.
+The ci-fix-v5 skill can also be invoked standalone (`/ci-fix-v5`) to diagnose and repair CI/CD issues outside of the orchestrator pipeline.
 
 ### 4.6 Rollback Safety
 
@@ -301,14 +306,14 @@ The orchestrator produces a comprehensive summary including:
 
 After testing the running application, issues and bugs will surface. **Triage is the formal re-entry point back into Phase 4** — it is not optional and not informal. Every bug or unexpected behavior that warrants a fix goes through triage before any code is written.
 
-Use **triage-v4** to investigate and formally capture findings:
+Use **triage-v5** to investigate and formally capture findings:
 
 - Triage runs in read-only mode — it never writes code
 - It investigates symptoms, traces root causes, and produces a GitHub issue as output
 - The resulting ticket feeds directly back into the Phase 4 orchestrator on the next development cycle
 - Ad-hoc fixes outside of this loop are prohibited — they bypass review gates and break the audit trail
 
-This creates a closed loop: **Phase 5 → triage-v4 → GitHub issue → Phase 4 → merge → Phase 6 → Phase 5**.
+This creates a closed loop: **Phase 5 → triage-v5 → GitHub issue → Phase 4 → merge → Phase 6 → Phase 5**.
 
 For ad-hoc debugging during investigation (not fixing), Claude Code can be used directly to trace behavior, inspect logs, or reproduce issues. The output of that investigation is always a ticket, never a direct code change.
 
@@ -345,7 +350,7 @@ Build Docker image (tagged {sha}-dev)
   → ✅ Eligible for Staging promotion
 ```
 
-Playwright UI tests run in CI on every PR (not post-deploy). Post-deploy validation is limited to smoke tests (health checks). If smoke fails, the deploy is broken. Fix via a new commit — do not attempt to patch around the pipeline.
+Playwright UI tests run on the **self-hosted runner via `workflow_dispatch`** — scoped per story during the pipeline and as a full suite at the end-of-run (CLEANUP) boundary. They are **not** a blocking gate on every PR (that would make every PR pay full browser-stack cost). Post-deploy validation is limited to smoke tests (health checks). If smoke fails, the deploy is broken. Fix via a new commit — do not attempt to patch around the pipeline.
 
 ### 6.2 Promote to Staging (manual)
 
@@ -430,10 +435,10 @@ Periodically review NuGet and npm package versions for security updates. This is
 
 If `main` is ever in a broken state (build fails, tests fail on main):
 
-1. **Try ci-fix-v4 first** — run `/ci-fix-v4` standalone to auto-diagnose and fix. If the orchestrator is running, it will have already attempted this via the background watcher.
-2. If ci-fix-v4 reports Blocked (cannot auto-fix), do not merge anything new until main is green.
+1. **Try ci-fix-v5 first** — run `/ci-fix-v5` standalone to auto-diagnose and fix. If the orchestrator is running, it will have already attempted this via the background watcher.
+2. If ci-fix-v5 reports Blocked (cannot auto-fix), do not merge anything new until main is green.
 3. Check the orchestrator's rollback tag (`pre-{STORY_ID}`) if the break was introduced during a development session.
-4. Create a triage ticket via triage-v4 for the underlying issue.
+4. Create a triage ticket via triage-v5 for the underlying issue.
 5. Fix via a normal branch → PR → review flow, not a direct push to main.
 
 ### 7.5 Returning to a Dormant Project
@@ -451,7 +456,7 @@ When picking up a project after significant time away:
 
 ## Key Principles
 
-**Context drift is the primary adversary.** The supervisor/worker pattern exists specifically to reset context on every sub-agent invocation. Each stage gets a fresh context with full standards loaded.
+**Context drift is the primary adversary.** Fresh sub-agents per stage — plus the orchestrator's own stateless relaunch — exist specifically to reset context on every invocation. Each stage gets a fresh context with full standards loaded.
 
 **Vertical slices over horizontal layers.** Stories deliver user-visible functionality. Foundation work is bounded to the minimum needed to unblock the first milestone. Entity lifecycle operations (create, list, view, delete) travel together.
 
@@ -469,32 +474,35 @@ When picking up a project after significant time away:
 
 ---
 
-## Skills Reference (v4)
+## Skills Reference (v5)
+
+All skills work under `standards/engineering-discipline.md` (ED-1..ED-4); the ticket-producing skills end with a three-part contribution (*what we missed / should consider / I'd add*).
 
 ### Story Creation & Backlog Maintenance
 | Skill | Purpose |
 |-------|---------|
-| prd-to-backlog-v4 | Bulk PRD decomposition into milestoned backlog |
-| add-story-v4 | Incremental story creation for existing projects |
-| reconcile-backlog-v4 | Reconcile PRD version changes against an existing backlog and codebase |
+| prd-to-backlog-v5 | Bulk PRD decomposition into milestoned backlog; nominates the repo-wide critical-path journeys |
+| add-story-v5 | Incremental story creation for existing projects; non-interactive mode for callers |
+| reconcile-backlog-v5 | Reconcile PRD version changes against an existing backlog and codebase (classifications grounded in source) |
 
-### Development Pipeline (per ticket, managed by orchestrate-v4)
+### Development Pipeline (per ticket, managed by orchestrate-v5)
 | Skill | Purpose |
 |-------|---------|
-| refine-story-v4 | Enrich issue with technical detail and acceptance criteria |
-| implement-ticket-v4 | Implement code, create PR. Supports fix mode for review feedback |
-| engineering-review-v4 | Review PR against standards. Implementation, integration-test, and ui-test modes |
-| security-review-v4 | OWASP Top 10 + infrastructure security review (auto-detects Bicep, Docker, GitHub Actions) |
-| ci-fix-v4 | Monitor GitHub Actions and auto-fix CI/CD failures. Background side-channel after each merge; standalone for ad-hoc repair |
-| integration-test-v4 | Write integration tests, create PR. Supports fix mode |
-| ui-test-v4 | Write Playwright UI tests, create PR. Supports fix mode |
-| orchestrate-v4 | Pipeline orchestrator with milestones, review loops, and observability |
+| refine-story-v5 | Enrich issue into a behavior-first tier table (one tier per behavior); adversarial self-review in all modes |
+| implement-ticket-v5 | Implement code + Unit/Contract tests, create PR. Supports fix mode for review feedback |
+| engineering-review-v5 | Review PR against standards + TR rules (two-way) and ED (ungrounded-claim check). Implementation, integration-test, and ui-test modes |
+| security-review-v5 | OWASP Top 10 + infrastructure security review (auto-detects Bicep, Docker, GitHub Actions) |
+| ci-fix-v5 | Monitor GitHub Actions and auto-fix CI/CD failures. Background side-channel after each merge; standalone for ad-hoc repair |
+| integration-test-v5 | Write integration tests, create PR. Supports fix mode |
+| ui-test-v5 | Write Playwright UI tests, create PR. Supports fix mode |
+| orchestrate-v5 | Mode-switching pipeline orchestrator (WORKING/CLEANUP), relaunched by the dumb loop; per-run tracking issue, TR gate-audit, observability |
+| monitor-v5 | Read-only live narrator for an orchestration run (stage/PR/CLEANUP events, stall flags); never writes |
 
 ### Investigation, Triage & Conformance
 | Skill | Purpose |
 |-------|---------|
-| triage-v4 | Interactive investigation and bug triage — never writes code, output is always a ticket |
-| conformance-v4 | Audit a project against TI Engineering Standards — informational only, produces a gap report |
+| triage-v5 | Interactive investigation and bug triage — evidence-first runtime diagnosis (pull the real exception before theorizing); never writes code, output is always a ticket |
+| conformance-v5 | Audit a project against TI Engineering Standards — informational only, produces a gap report |
 
 ### Standards
 | File | Purpose |
@@ -502,7 +510,8 @@ When picking up a project after significant time away:
 | story-writing-standards.md | Story structure, vertical slices, milestones, sizing, acceptance criteria |
 | project-tracking.md | Board structure, labels, custom fields, issue types |
 | environments.md | Environment definitions, Bicep conventions, pipeline structure, promotion flow, conformance checklist |
-| testing.md | Testing philosophy, frameworks, tiers, CI/CD gates, pre-existing failure rules |
+| testing.md | Four-tier test model (Unit/Contract/Integration/UI), TR-1..TR-11 rules, CI/CD trigger model, critical-path |
+| engineering-discipline.md | How to work: grounded claims + adversarial self-review (ED-1..ED-4) |
 | git-workflow.md | Branching, commits, PR process, deployment strategy |
 | architecture.md | Dependency inversion, interface-first design, project layering |
 | api-design.md | Endpoint return types, DTOs, serialization, naming conventions |

--- a/workflow/screen-inventory-template.md
+++ b/workflow/screen-inventory-template.md
@@ -65,6 +65,8 @@ Claude will organize your descriptions into the structure below. Don't worry abo
 - **Loading:** [e.g., "Skeleton placeholders for cards and table rows"]
 - **Error:** [e.g., "Inline error banner above the table with retry action"]
 
+**UI-tier scope (TR-5 / TR-6):** [In scope | Out of scope — and why] Record per surface whether a UI-tier (Playwright) test covers it. Most surfaces are **out of scope** — a lower tier already catches the behavior. A surface is in scope only if it carries a journey worth an end-to-end test, and a **critical-path** journey (auth, the core create→read flow, the money path) is called out explicitly so `refine-story-v5` can declare it and `ui-test-v5` can tag it. The repo-wide critical-path set is capped at 10 (TR-6). See [standards/testing.md](../standards/testing.md).
+
 **Notes / Open questions:**
 - [Anything unresolved — e.g., "Do we need real-time updates or is polling okay?"]
 - [Design considerations — e.g., "Table might need horizontal scroll on mobile"]

--- a/workflow/workflow-diagram.html
+++ b/workflow/workflow-diagram.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>TI Agentic Development Workflow — v4</title>
+<title>TI Agentic Development Workflow — v5</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&display=swap');
 
@@ -347,7 +347,7 @@
 
 <div class="header">
   <h1>agentic<span>.</span>workflow</h1>
-  <div class="version">v4 — PR-Based Pipeline with Milestones & Observability</div>
+  <div class="version">v5 — Mode-Switching Pipeline (WORKING / CLEANUP), relaunched by the dumb loop</div>
   <p>Full lifecycle from brainstorm to reviewed, tested, merged code — orchestrating Claude Web, Claude Code, and GitHub with automated engineering and security review gates.</p>
   <div class="legend">
     <div class="legend-item"><div class="legend-dot" style="background:var(--phase-discovery)"></div>Discovery</div>
@@ -470,14 +470,14 @@
         <div class="step">
           <div class="step-label" style="color:var(--phase-bootstrap)"><span class="icon">📚</span> Standards Sync</div>
           <h3>Pull Shared Standards</h3>
-          <p>Clone or pull TI-Engineering-Standards. Sync v4 skills into project. Read all standards files.</p>
+          <p>Clone or pull TI-Engineering-Standards. Sync v5 skills into project. Read all standards files.</p>
           <div class="tools"><span class="tool-tag">Auto-sync protocol</span></div>
         </div>
         <div class="step">
           <div class="step-label" style="color:var(--phase-bootstrap)"><span class="icon">📊</span> Backlog Generation</div>
-          <h3>prd-to-backlog-v4</h3>
+          <h3>prd-to-backlog-v5</h3>
           <p>Decompose PRD + Screen Inventory + Decisions Log into vertical-slice stories grouped by milestones. Human approves plan before issues are created.</p>
-          <div class="tools"><span class="tool-tag">prd-to-backlog-v4</span></div>
+          <div class="tools"><span class="tool-tag">prd-to-backlog-v5</span></div>
         </div>
       </div>
 
@@ -500,11 +500,11 @@
     <div class="phase-header">
       <div class="phase-number" style="background:rgba(78,205,196,0.15);color:var(--phase-dev)">04</div>
       <div class="phase-title" style="color:var(--phase-dev)">Orchestrated Development</div>
-      <div class="phase-subtitle">orchestrate-v4 — PR-Based Pipeline</div>
+      <div class="phase-subtitle">orchestrate-v5 — mode-switching pipeline (WORKING / CLEANUP)</div>
     </div>
     <div class="steps">
       <div class="orchestrator-box">
-        <div class="orch-label">▸ orchestrate-v4 — Per Ticket Pipeline</div>
+        <div class="orch-label">▸ orchestrate-v5 — relaunched each loop; reads the tracking issue; self-selects WORKING / CLEANUP</div>
 
         <div class="step-row triple" style="margin-top:12px">
           <div class="step" style="border-color:rgba(78,205,196,0.2)">
@@ -514,8 +514,8 @@
           </div>
           <div class="step" style="border-color:rgba(78,205,196,0.2)">
             <div class="step-label" style="color:var(--phase-dev)"><span class="icon">🔄</span> Mode Gate</div>
-            <h3>Supervised / Autonomous</h3>
-            <p>Supervised: stop between tickets. Autonomous: continue, stopping only at milestones and circuit breakers.</p>
+            <h3>Run mode: WORKING / CLEANUP</h3>
+            <p>WORKING: process up to N ready tickets, checkpoint to the tracking issue, exit (the loop relaunches it). CLEANUP: end-of-run oversight. Supervised vs autonomous is an orthogonal cadence control.</p>
           </div>
           <div class="step" style="border-color:rgba(78,205,196,0.2)">
             <div class="step-label" style="color:var(--phase-dev)"><span class="icon">📈</span> Observability</div>
@@ -530,24 +530,24 @@
           <div class="pipeline-stage active" data-stage="1">
             <div class="step" style="border-color:rgba(78,205,196,0.15);background:rgba(78,205,196,0.02)">
               <div class="step-label" style="color:var(--phase-dev)"><span class="icon">📖</span> Refine</div>
-              <h3>refine-story-v4</h3>
-              <p>Enrich issue with technical detail, codebase context, and expanded acceptance criteria. Autonomous decisions in orchestrator mode.</p>
+              <h3>refine-story-v5</h3>
+              <p>Behavior-first tier table — one tier per behavior (TR-1); critical journeys declared (TR-6); adversarial self-review in all modes (ED-2).</p>
             </div>
           </div>
 
           <div class="pipeline-stage active" data-stage="2">
             <div class="step" style="border-color:rgba(78,205,196,0.15);background:rgba(78,205,196,0.02)">
               <div class="step-label" style="color:var(--phase-dev)"><span class="icon">⚡</span> Implement</div>
-              <h3>implement-ticket-v4 → PR #1</h3>
-              <p>Fresh context. Load all standards. Explore → Plan → Implement → Unit Test → Commit → Push → Create PR. Build order: Domain → Fakes → Infrastructure → Api.</p>
+              <h3>implement-ticket-v5 → PR #1</h3>
+              <p>Fresh context. Load all standards. Explore → Plan → Implement → Unit + Contract tests → adversarial self-review (ED-2) → Commit → Push → Create PR. Build order: Domain → Fakes → Infrastructure → Api.</p>
             </div>
           </div>
 
           <div class="pipeline-stage review" data-stage="3">
             <div class="step" style="border-color:rgba(240,152,72,0.2);background:rgba(240,152,72,0.02)">
               <div class="step-label" style="color:var(--accent-orange)"><span class="icon">🔎</span> Engineering Review</div>
-              <h3>engineering-review-v4 (implementation mode)</h3>
-              <p>Independent context reviews PR against all 13 standards files. Posts line-level comments with standards references. Approves or requests changes.</p>
+              <h3>engineering-review-v5 (implementation mode)</h3>
+              <p>Independent context reviews PR against standards + TR rules (two-way) and the ungrounded-claim check (ED-1). Posts line-level comments. Approves or requests changes.</p>
               <div class="review-loop">↻ Loop: reviewer ↔ implementer fix mode — max 3 iterations</div>
             </div>
           </div>
@@ -555,7 +555,7 @@
           <div class="pipeline-stage security" data-stage="3.5">
             <div class="step" style="border-color:rgba(232,99,122,0.2);background:rgba(232,99,122,0.02)">
               <div class="step-label" style="color:var(--accent-rose)"><span class="icon">🛡️</span> Security Review</div>
-              <h3>security-review-v4 (OWASP Top 10 + Infrastructure)</h3>
+              <h3>security-review-v5 (OWASP Top 10 + Infrastructure)</h3>
               <p>Framework-aware OWASP analysis with attack vector requirements. Auto-detects infrastructure files (Bicep, Docker, GitHub Actions) and runs infrastructure security checklist. On pass → merge PR #1.</p>
               <div class="review-loop">↻ Loop: reviewer ↔ implementer fix mode — max 2 iterations</div>
             </div>
@@ -564,7 +564,7 @@
           <div class="pipeline-stage test" data-stage="4">
             <div class="step" style="border-color:rgba(167,139,250,0.2);background:rgba(167,139,250,0.02)">
               <div class="step-label" style="color:var(--accent-purple)"><span class="icon">🧪</span> Integration Tests</div>
-              <h3>integration-test-v4 → PR #2</h3>
+              <h3>integration-test-v5 → PR #2</h3>
               <p>Independent context writes tests against acceptance criteria (not developer's description). Testcontainers, real database, data isolation. Branches from updated main.</p>
             </div>
           </div>
@@ -572,8 +572,8 @@
           <div class="pipeline-stage review" data-stage="5">
             <div class="step" style="border-color:rgba(240,152,72,0.2);background:rgba(240,152,72,0.02)">
               <div class="step-label" style="color:var(--accent-orange)"><span class="icon">🔎</span> Engineering Review</div>
-              <h3>engineering-review-v4 (integration-tests mode)</h3>
-              <p>Reviews test quality, coverage, patterns. On approve → check off acceptance criteria → merge PR #2 → close issue.</p>
+              <h3>engineering-review-v5 (integration-tests mode)</h3>
+              <p>Reviews integration-test quality — real-infra behavior only, no contract re-assertion (TR-3). On approve → merge PR #2. (Issue closes at stage 8, after all tiers merge.)</p>
               <div class="review-loop">↻ Loop: reviewer ↔ test-writer fix mode — max 3 iterations</div>
             </div>
           </div>
@@ -581,15 +581,15 @@
           <div class="pipeline-stage test" data-stage="6">
             <div class="step" style="border-color:rgba(167,139,250,0.2);background:rgba(167,139,250,0.02)">
               <div class="step-label" style="color:var(--accent-purple)"><span class="icon">🎭</span> UI Tests</div>
-              <h3>ui-test-v4 → PR #3</h3>
-              <p>Independent context writes Playwright tests using Page Object Model. Semantic selectors, fresh browser context, auth bypass. Branches from updated main.</p>
+              <h3>ui-test-v5 → PR #3</h3>
+              <p>Journey-scoped Playwright (POM, condition-based waits — TR-4/9). Dispatched on the self-hosted runner via workflow_dispatch — not a blocking per-PR gate. Critical-path journeys tagged (TR-6).</p>
             </div>
           </div>
 
           <div class="pipeline-stage review" data-stage="7">
             <div class="step" style="border-color:rgba(240,152,72,0.2);background:rgba(240,152,72,0.02)">
               <div class="step-label" style="color:var(--accent-orange)"><span class="icon">🔎</span> Engineering Review</div>
-              <h3>engineering-review-v4 (ui-tests mode)</h3>
+              <h3>engineering-review-v5 (ui-tests mode)</h3>
               <p>Reviews UI test quality, Page Object Model patterns, semantic selectors, coverage. On approve → merge PR #3.</p>
               <div class="review-loop">↻ Loop: reviewer ↔ test-writer fix mode — max 3 iterations</div>
             </div>
@@ -599,7 +599,7 @@
             <div class="step" style="border-color:rgba(78,205,196,0.15);background:rgba(78,205,196,0.02)">
               <div class="step-label" style="color:var(--accent-green)"><span class="icon">✔️</span> Close</div>
               <h3>Finalize</h3>
-              <p>Check off acceptance criteria, close issue. Board automation moves to Done. Delete rollback tag. Capture ticket metrics.</p>
+              <p>Orchestrator checks off acceptance criteria and closes the issue (it owns the close), checkpoints the ticket to the tracking issue, deletes the rollback tag, captures metrics.</p>
             </div>
           </div>
 
@@ -611,6 +611,15 @@
           <p>When a <code>milestone</code>-labeled issue is encountered, the orchestrator <strong>stops regardless of mode</strong>. Runs the smoke test checklist, reports results, and waits for human approval. The developer launches the app, clicks through, and validates before work continues.</p>
         </div>
 
+        <!-- Background CI watcher -->
+        <div class="step-row single" style="margin-top:12px">
+          <div class="step" style="border-color:rgba(167,139,250,0.2)">
+            <div class="step-label" style="color:var(--accent-purple)"><span class="icon">📡</span> Background CI Watcher</div>
+            <h3>ci-fix-v5 WATCH — after every merge</h3>
+            <p>After each PR merge the orchestrator spawns <code>ci-fix-v5</code> in WATCH mode in the background and continues immediately. If CI goes red it spawns <code>ci-fix-v5</code> FIX (fix the code, not the test — TR-7), which repairs on its own branch in parallel; a Blocked fix trips a circuit breaker. <code>monitor-v5</code> narrates the run read-only.</p>
+          </div>
+        </div>
+
         <!-- Circuit breakers -->
         <div class="step-row single" style="margin-top:12px">
           <div class="step" style="border-color:rgba(232,99,122,0.2)">
@@ -620,6 +629,18 @@
           </div>
         </div>
 
+      </div>
+
+      <!-- CLEANUP mode -->
+      <div class="orchestrator-box" style="margin-top:16px">
+        <div class="orch-label">▸ orchestrate-v5 — CLEANUP (when "Up Next" is empty)</div>
+        <div class="step-row single" style="margin-top:12px">
+          <div class="step" style="border-color:rgba(78,205,196,0.2)">
+            <div class="step-label" style="color:var(--phase-dev)"><span class="icon">🧹</span> End-of-Run Oversight</div>
+            <h3>Full UI dispatch · pyramid ratio · TR gate-audit</h3>
+            <p>With no ready tickets left, the relaunched orchestrator runs CLEANUP: dispatch the full UI suite on the runner, check the test-pyramid ratio and raise a drift ticket, audit the TR sign-off grids across the run, inject any fix tickets, then either reach a fixpoint and close the run (<code>RUN_COMPLETE</code>) or exit and re-verify on the next loop.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -706,7 +727,7 @@
     </div>
   </div>
 
-  <div class="phase-divider"><span>Feedback Loop — triage-v4 → new tickets → Phase 4</span></div>
+  <div class="phase-divider"><span>Feedback Loop — triage-v5 → new tickets → Phase 4</span></div>
 
   <!-- PHASE 7 -->
   <div class="phase">
@@ -726,15 +747,15 @@
         </div>
         <div class="step">
           <div class="step-label" style="color:var(--accent-blue)"><span class="icon">📋</span> Conformance Audit</div>
-          <h3>conformance-v4</h3>
+          <h3>conformance-v5</h3>
           <p>Audit the project against all standards — pipeline, environments, code, testing. Produces a gap report with pass/fail per check. No changes made — informational only.</p>
-          <div class="tools"><span class="tool-tag">conformance-v4</span></div>
+          <div class="tools"><span class="tool-tag">conformance-v5</span></div>
         </div>
         <div class="step">
           <div class="step-label" style="color:var(--accent-blue)"><span class="icon">🔧</span> Maintenance</div>
           <h3>Dependencies & Recovery</h3>
           <p>Dependency updates via task tickets (not ad-hoc). Broken main recovery uses rollback tags. Dormant projects: re-sync, test, deploy to Dev, review board, then resume.</p>
-          <div class="tools"><span class="tool-tag">triage-v4</span><span class="tool-tag">Task tickets</span></div>
+          <div class="tools"><span class="tool-tag">triage-v5</span><span class="tool-tag">Task tickets</span></div>
         </div>
       </div>
 


### PR DESCRIPTION
Phase 6 process-documentation — the workflow layer was heavily v4-coded and contradicted what shipped (e.g. "Playwright runs in CI on every PR", "supervisor/worker"). This brings it fully to v5. **All six v5-plan phases are now complete.**

## What changed
- **6.1 agentic-development-workflow.md** — all `-v4` → `-v5`; supervisor/worker → stateless WORKING/CLEANUP orchestrator relaunched by the dumb loop; corrected the every-PR-Playwright claim → runner/`workflow_dispatch`; four-tier testing + ED + three-part contribution; Skills Reference → v5 (+ `monitor-v5`, `engineering-discipline.md`).
- **6.3 README.md** — v5 per-ticket pipeline, mode-switching orchestrator, UI on the runner, ED discipline.
- **6.4 screen-inventory-template.md** — per-surface UI-scope decision (TR-5/TR-6).
- **6.2 workflow-diagram.html** — redrawn to the v5 topology: WORKING/CLEANUP run-mode + relaunch loop, tier-aware stage descriptions, UI dispatched on the self-hosted runner, a background `ci-fix-v5` WATCH box, and a CLEANUP end-of-run box. Div-balanced.
- **6.6 developer-tools/self-hosted-runner-setup.md** — new guide: prerequisites, register, install-as-service, WSL2 persistence, Docker access, smoke-test, hygiene, troubleshooting. Grounded in the workflow templates + standard `actions/runner` install.
- **6.7 CLAUDE.md** — indexes `workflow/`, `templates/workflows`, `templates/scripts`, `developer-tools/` + the runner guide.
- **6.5 templates/CLAUDE-project.md** — verified already v5-aligned; no change needed.
- Plan: Phase 5 + Phase 6 marked COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)