### PR TITLE
discipline: ED-5 (mandatory terminal contribution) + triage ticket-numbering fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ These habits apply to **every task on every project** — see [standards/enginee
 - **Falsify, don't rubber-stamp (ED-2).** Treat your own just-produced spec/ticket/PR as a suspect — try to break each claim before finalizing it.
 - **Label hypotheses (ED-3).** An ungrounded claim is written as a hypothesis with the evidence needed to settle it, never as established fact.
 - **Surface scope forks (ED-4).** If the chosen approach changes blast radius or which test tiers apply, say so — never let a ticket hide it.
+- **Contribute, last (ED-5).** When producing/refining a ticket, volunteer your own take — *what we missed / should consider / I'd add* — automatically, as the final, non-skippable step. It must be the wrap-up, or it gets skipped.
 
 ---
 

--- a/skills/add-story-v5/SKILL.md
+++ b/skills/add-story-v5/SKILL.md
@@ -10,7 +10,7 @@ You are adding stories to an existing project backlog. You work conversationally
 
 You do NOT implement anything. You produce stories.
 
-**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). When a story references how the existing code behaves (an entity, an endpoint, a screen, a pattern to follow), **ground it in the source (ED-1)** — don't assert from a plausible mental model. Before creating issues, adversarially re-check your proposal (ED-2) and **surface your own take** — what we missed / should consider / I'd add (Phase 3.5). Cite the ED rules by ID; do not restate them.
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-5). When a story references how the existing code behaves (an entity, an endpoint, a screen, a pattern to follow), **ground it in the source (ED-1)** — don't assert from a plausible mental model. Before creating issues, adversarially re-check your proposal (ED-2) and **surface your own take** — what we missed / should consider / I'd add (Phase 3.5). Cite the ED rules by ID; do not restate them.
 
 **Mode:** Standalone/interactive by default. When invoked **non-interactively** by another skill (`reconcile-backlog-v5`) or the orchestrator — signalled by the caller passing a full story spec and `NONINTERACTIVE=true` — skip the clarifying questions (Phase 2) and the conversational surfacing in Phase 3.5; make best-judgment decisions from codebase patterns and fold the contribution items into the issue body instead. The grounding (ED-1) and adversarial self-review (ED-2) still run.
 
@@ -140,7 +140,7 @@ Before creating anything, cross-examine your own proposal, then volunteer your t
 
 **Adversarial self-review (ED-2) — runs in every mode.** Re-check each story against the source: do the entities, screens, endpoints, and "follow the existing pattern" references actually exist as described (ED-1)? Anything you couldn't confirm is flagged, not assumed (ED-3). Does any story silently change blast radius or pull in more than its slice implies (ED-4)?
 
-**Surface your own take (the three-part contribution) — interactive mode.** Volunteer this without being asked; it's the question the user always asks when writing a ticket. Plain prose, four parts:
+**Surface your own take (the three-part contribution) — ED-5, mandatory.** Volunteer this without being asked, *at this pre-creation checkpoint* so the user can act on it before issues are made. It is not optional and not skippable; if a section has nothing material, say so explicitly ("nothing I'd add") — silence is not the same as surfacing it. Plain prose, four parts:
 
 - **What we missed** — capabilities, edge cases, or dependencies the description didn't mention but the backlog/codebase implies
 - **What we should consider** — sequencing, milestone boundaries, alternatives to the proposed split
@@ -250,6 +250,8 @@ If adding stories to an **existing** milestone, use the same process — get the
 
 ### 4d. Confirm
 
+> **ED-5 backstop:** the creation report below does **not** replace your proactive contribution. You must have surfaced it at the Phase 3.5 checkpoint — if you reached this step without doing so, surface it now before confirming.
+
 Tell the user what was created:
 
 ```markdown
@@ -265,7 +267,7 @@ Tell the user what was created:
 ```
 
 ---
-<!-- skill-version: 5.1 -->
-<!-- last-updated: 2026-06-27 -->
+<!-- skill-version: 5.2 -->
+<!-- last-updated: 2026-06-28 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/skills/prd-to-backlog-v5/SKILL.md
+++ b/skills/prd-to-backlog-v5/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[path to PRD] [optional: --screen-inventory path] [optional: --d
 
 You are converting a PRD into a development backlog. You produce well-structured, right-sized stories with milestones following TI story-writing standards. You create GitHub issues and organize them on the project board.
 
-**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Ground decomposition claims about existing code in the source (ED-1); adversarially re-check the backlog and **surface your own take** before creating issues (ED-2, Phase 2.5). The backlog is also the natural place to **budget the repo-wide critical-path journeys** (TR-6 ceiling is 10 across the whole repo) — nominate them once here (Phase 1f) so refine/ui-test draw from a budgeted pool instead of each story minting its own. Cite ED/TR rules by ID; do not restate them.
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-5). Ground decomposition claims about existing code in the source (ED-1); adversarially re-check the backlog and **surface your own take** before creating issues (ED-2, Phase 2.5). The backlog is also the natural place to **budget the repo-wide critical-path journeys** (TR-6 ceiling is 10 across the whole repo) — nominate them once here (Phase 1f) so refine/ui-test draw from a budgeted pool instead of each story minting its own. Cite ED/TR rules by ID; do not restate them.
 
 You do NOT implement anything. You produce stories.
 
@@ -170,7 +170,7 @@ Before creating issues, cross-examine the backlog, then volunteer your take.
 
 **Adversarial self-review (ED-2).** Re-check claims about the existing codebase against the source (ED-1) — foundation work that may already exist, entities/screens assumed present. Is the critical-path list within the ≤10 ceiling and genuinely the highest-value flows (ED-4 — an over-budget set is a scope fork)? Anything unconfirmed is flagged, not assumed (ED-3).
 
-**Surface your own take (the three-part contribution).** Volunteer this without being asked:
+**Surface your own take (the three-part contribution) — ED-5, mandatory.** Volunteer this without being asked, *together with the Phase 2 plan* (re-present if needed) so the user can act on it before any issues are created. Not optional, not skippable; if a section has nothing material, say so explicitly. Four parts:
 
 - **What we missed** — capabilities/screens/flows implied by the PRD but absent from the decomposition; foundation work not called out
 - **What we should consider** — alternative milestone boundaries, story splits/merges, sequencing risks, the critical-path nominations
@@ -321,6 +321,8 @@ For each milestone, for each story in that milestone:
 
 ## Phase 4: Report
 
+> **ED-5 backstop:** this creation report does **not** replace your proactive contribution — that must have been surfaced with the Phase 2.5 plan. Don't let "backlog created" stand in for it.
+
 ```markdown
 ## Backlog Created
 
@@ -342,7 +344,7 @@ For each milestone, for each story in that milestone:
 ```
 
 ---
-<!-- skill-version: 5.1 -->
-<!-- last-updated: 2026-06-27 -->
+<!-- skill-version: 5.2 -->
+<!-- last-updated: 2026-06-28 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/skills/reconcile-backlog-v5/SKILL.md
+++ b/skills/reconcile-backlog-v5/SKILL.md
@@ -10,7 +10,7 @@ You are reconciling changes between two versions of a PRD against an existing pr
 
 You do NOT implement anything. You produce and update stories.
 
-**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Your classifications hinge on claims about what's already built — **"already implemented", "needs a code change", "unaffected"** — and those are exactly the claims most likely to be plausible-but-wrong. **Ground every "already built / not built" classification in the source (ED-1)**; never classify from a plausible memory of the codebase. Adversarially re-check the classification set and **surface your own take** before executing (ED-2, Phase 4). Anything you can't confirm is flagged, not assumed (ED-3). Cite the ED rules by ID; do not restate them.
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-5). Your classifications hinge on claims about what's already built — **"already implemented", "needs a code change", "unaffected"** — and those are exactly the claims most likely to be plausible-but-wrong. **Ground every "already built / not built" classification in the source (ED-1)**; never classify from a plausible memory of the codebase. Adversarially re-check the classification set and **surface your own take** before executing (ED-2, Phase 4). Anything you can't confirm is flagged, not assumed (ED-3). Cite the ED rules by ID; do not restate them.
 
 ---
 
@@ -293,7 +293,7 @@ Present the full plan to the user in conversation. Structure it as:
 Cross-examine the classification set, then volunteer your take alongside the plan:
 
 - **Adversarial self-review (ED-2).** For every "already built / unaffected / needs a code change" classification, confirm it against the source (ED-1) — open the file, don't classify from memory. A wrong "already built" silently drops needed work; a wrong "needs change" creates phantom tickets. Anything unconfirmed is flagged as a hypothesis (ED-3), not a settled classification.
-- **Surface your own take (the three-part contribution):**
+- **Surface your own take (the three-part contribution) — ED-5, mandatory.** Volunteer it alongside the plan, every time; not optional, not skippable; if a section has nothing material, say so explicitly:
   - **What we missed** — PRD deltas with no row, or ripple effects of a change beyond the obvious ticket
   - **What we should consider** — classifications you were unsure about, merges/splits, sequencing
   - **What I'd add** — flag tickets or watch-outs the diff implies
@@ -411,6 +411,8 @@ Mark all rows in the reconciliation progress table as `✅ Done`.
 
 ## Phase 6: Report
 
+> **ED-5 backstop:** this report does not replace your proactive contribution — that must have been surfaced with the Phase 4 plan. Don't let "reconciliation complete" stand in for it.
+
 ```markdown
 ## Reconciliation Complete: {Old Version} → {New Version}
 
@@ -458,7 +460,7 @@ If the skill is re-invoked or context is compressed mid-run:
 3. **Resume from the incomplete phase** — do not repeat completed work
 
 ---
-<!-- skill-version: 5.0 -->
-<!-- last-updated: 2026-06-27 -->
+<!-- skill-version: 5.1 -->
+<!-- last-updated: 2026-06-28 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/skills/refine-story-v5/SKILL.md
+++ b/skills/refine-story-v5/SKILL.md
@@ -10,7 +10,7 @@ You are refining a GitHub issue into a complete, implementation-ready specificat
 
 This skill is the **seed** step of *define → seed → enforce*: `standards/testing.md` defines the test tiers and Test Rules (TR-*), refine seeds them into the issue (a behavior-first test plan), and `engineering-review-v5` enforces them. Cite the TR rules by ID; do not restate them.
 
-**Work the spec under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). A refined spec is the single biggest place a confident-but-wrong assumption hides: this skill once asserted a data flow it never traced to the type. So every claim you write about how the code behaves is **grounded to an observed `file:line` (ED-1)**, the finished spec gets an **adversarial self-review (ED-2)** before it ships (Phase 3.5), anything you can't ground is **labeled a hypothesis (ED-3)**, and any approach that changes blast radius or test tiers is **surfaced as a scope fork (ED-4)**. Cite the ED rules by ID; do not restate them.
+**Work the spec under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-5). A refined spec is the single biggest place a confident-but-wrong assumption hides: this skill once asserted a data flow it never traced to the type. So every claim you write about how the code behaves is **grounded to an observed `file:line` (ED-1)**, the finished spec gets an **adversarial self-review (ED-2)** before it ships (Phase 3.5), anything you can't ground is **labeled a hypothesis (ED-3)**, and any approach that changes blast radius or test tiers is **surfaced as a scope fork (ED-4)**. Cite the ED rules by ID; do not restate them.
 
 **Orchestrator Mode:** When `{ORCHESTRATOR_MODE}` is `true` (substituted by the orchestrator), skip interactive questions (Phase 3) and make best-judgment decisions. When running standalone (the literal `{ORCHESTRATOR_MODE}` appears unsubstituted), use interactive mode.
 
@@ -215,18 +215,20 @@ For every claim the spec asserts about how the code behaves — each data flow, 
 
 Concretely: open the type/endpoint/effect and confirm before the spec states it as fact. (A two-minute grep of the response type is what collapses an `overallGrade`-class data-flow error before it ever reaches the ticket.)
 
-### Proactive contribution — what I'd add (interactive mode only)
+### Prepare your proactive contribution (ED-5)
 
-After resolving decisions and the adversarial self-review, **automatically volunteer your own take on the ticket — without being asked.** This is the question the human always asks when writing a ticket; surface it every time so they don't have to prompt for it. Four parts:
+From the adversarial self-review, assemble your own take on the ticket — four parts:
 
 - **What we missed** — gaps you see in the ticket
 - **What we should consider** — angles, options, risks worth raising
 - **What I'd add** — your own recommendations to strengthen it
 - **What I considered and set aside** — options weighed and rejected, tradeoffs resolved silently
 
-Plain prose; **no taxonomy buckets** — surface the items directly. The user can keep probing from there. A genuine scope-fork (ED-4) that changes the work gets escalated as a decision, not buried in prose.
+Plain prose; **no taxonomy buckets**. A genuine scope-fork (ED-4) that changes the work gets escalated as a decision, not buried in prose.
 
-**If `{ORCHESTRATOR_MODE}` is `true`, SKIP only this conversational surfacing** (not Phase 3.5) — instead fold the adversarial-review findings, any hypotheses (ED-3), and contribution items into the issue comment (4c), and create a follow-up ticket for any genuine scope-fork.
+**You do not deliver it here — you deliver it in 4e as the terminal output (ED-5).** This is deliberate: the contribution is the only output that produces no durable artifact, so if it's surfaced mid-skill it gets swallowed by the "issue updated, report done" wrap-up. Prepare it now; surface it *last*.
+
+**If `{ORCHESTRATOR_MODE}` is `true`** (no human): don't surface conversationally — instead fold the adversarial-review findings, any hypotheses (ED-3), and contribution items into the issue comment (4c), and create a follow-up ticket for any genuine scope-fork.
 
 ## Phase 4: Update the Issue
 
@@ -397,9 +399,14 @@ EOF
 
 ### 4e. Confirm / Report
 
-**Standalone mode:** Tell the user the issue has been updated and moved to "Up Next", with a link.
+**Standalone mode — the refinement is NOT complete until you do this (ED-5).** Your final message to the user has two parts, in this order:
 
-**Orchestrator mode:** Return a structured report:
+1. **Your proactive contribution** (the four-part take you prepared in Phase 3.5) — *what we missed / what we should consider / what I'd add / what I considered and set aside*. This is mandatory and comes first. Do not let "the issue is updated" stand in for it.
+2. Then the confirmation: the issue has been updated and moved to "Up Next", with a link.
+
+If you have nothing material for a section, say so explicitly ("nothing I'd add beyond the spec") — silence is not the same as having surfaced it. A genuine scope-fork goes to the user as a decision, not a prose aside.
+
+**Orchestrator mode:** Return a structured report (the contribution was folded into the issue comment per Phase 3.5):
 
 ```
 STATUS: Refined
@@ -409,10 +416,11 @@ DECISIONS_COUNT: [number of decisions made]
 SECTIONS_UPDATED: [comma-separated list]
 BEHAVIORS_COUNT: [rows in the behavior-first Test Coverage table]
 CRITICAL_PATH_COUNT: [behaviors marked Critical? ✓ | 0]
+CONTRIBUTION_SURFACED: [standalone: yes — to the user | orchestrator: folded into issue comment]
 OPEN_QUESTIONS: [None | count]
 ```
 
 ---
-<!-- skill-version: 5.2 -->
-<!-- last-updated: 2026-06-27 -->
+<!-- skill-version: 5.3 -->
+<!-- last-updated: 2026-06-28 -->
 <!-- pipeline: v5 -->

--- a/skills/triage-v5/SKILL.md
+++ b/skills/triage-v5/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-v5
-description: "Interactive investigation and bug triage. Explores codebase, pulls real runtime errors before theorizing, diagnoses issues, and creates/updates GitHub tickets. Never writes code. Evidence-first + grounded/adversarial discipline (ED-1..ED-4)."
+description: "Interactive investigation and bug triage. Explores codebase, pulls real runtime errors before theorizing, diagnoses issues, and creates/updates GitHub tickets. Never writes code. Evidence-first + grounded/adversarial discipline (ED-1..ED-5)."
 argument-hint: "[description of issue to investigate, or leave blank for interactive mode]"
 ---
 
@@ -8,7 +8,7 @@ argument-hint: "[description of issue to investigate, or leave blank for interac
 
 You are in **triage mode**. Your job is to investigate, diagnose, and produce GitHub tickets. You do NOT write code.
 
-**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-4). Triage's entire value is the reasoning trail, so the discipline is non-negotiable here: **reason backward from the actual error, not forward from the symptom.** A confident-but-wrong root cause is worse than none — it sends someone to "fix" already-correct code. Ground every claim in observed evidence (ED-1), label anything you can't confirm as a hypothesis (ED-3), and adversarially re-check your own diagnosis before it becomes a ticket (ED-2). Cite the ED rules by ID; do not restate them.
+**Work under engineering discipline** (`standards/engineering-discipline.md`, ED-1..ED-5). Triage's entire value is the reasoning trail, so the discipline is non-negotiable here: **reason backward from the actual error, not forward from the symptom.** A confident-but-wrong root cause is worse than none — it sends someone to "fix" already-correct code. Ground every claim in observed evidence (ED-1), label anything you can't confirm as a hypothesis (ED-3), and adversarially re-check your own diagnosis before it becomes a ticket (ED-2). Cite the ED rules by ID; do not restate them.
 
 ## Hard Rules
 
@@ -162,9 +162,9 @@ Before you present the draft, cross-examine your own diagnosis — try to prove 
 - **What else could explain the symptom?** Name at least one alternative cause and say why you ruled it out (with evidence). The "obvious" infrastructure explanation is the classic trap.
 - **Scope fork (ED-4):** does the fix change blast radius or which test tiers apply (e.g. a "config" bug that's actually a code change across projects)? Flag it.
 
-### Surface your own take (the three-part contribution)
+### Surface your own take (the three-part contribution) — ED-5, mandatory
 
-When you present the draft, also volunteer your own input — without being asked. Plain prose, four parts:
+When you present the draft, also volunteer your own input — without being asked, every time. Not optional, not skippable; if a section has nothing material, say so explicitly. Plain prose, four parts:
 
 - **What we missed** — gaps in the ticket; evidence you couldn't pull but should ("grab the exception at `{path}` to confirm")
 - **What we should consider** — alternative causes, related areas the same root cause might affect, severity/priority angles
@@ -326,6 +326,8 @@ EOF
 
 ### 3c. Confirm
 
+> **ED-5 backstop:** the confirmation below does not replace your proactive contribution — that must have been surfaced with the Phase 2 draft. Don't let "ticket created" stand in for it.
+
 Post confirmation with the issue link:
 
 ```markdown
@@ -347,7 +349,7 @@ If the user describes another issue, loop back to **Phase 1**.
 Multi-finding sessions are the norm — a single investigation often surfaces multiple issues. Each gets its own ticket.
 
 ---
-<!-- skill-version: 5.1 -->
-<!-- last-updated: 2026-06-27 -->
+<!-- skill-version: 5.2 -->
+<!-- last-updated: 2026-06-28 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/skills/triage-v5/SKILL.md
+++ b/skills/triage-v5/SKILL.md
@@ -247,10 +247,13 @@ EOF
 )"
 ```
 
-After creation, **backfill the Story ID into the body** (the number didn't exist at create time — keep `{ISSUE_NUM}` literal in the body, this fills it). Mechanical and non-optional:
+After creation, **extract the number, prefix the title with the Story ID, and backfill the Story ID into the body** (the number didn't exist at create time — keep `{ISSUE_NUM}` literal in the body, this fills it). All three are mechanical and non-optional — the title prefix is what shows the Story ID (e.g. `HC-474`) in every board/issue list:
 
 ```bash
 ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+# Prefix the title with the Story ID (e.g. "HC-474: {Title}")
+gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --title "{PREFIX}-${ISSUE_NUM}: {Title}"
+# Backfill the Story ID into the body
 gh issue view $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --json body -q .body \
   | sed "s/{ISSUE_NUM}/${ISSUE_NUM}/g" \
   | gh issue edit $ISSUE_NUM --repo {REPO_OWNER}/{REPO_NAME} --body-file -
@@ -289,7 +292,7 @@ gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){u
 # 6. Story ID (text field — e.g., "FI-263")
 gh api graphql -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{text:$val}}){projectV2Item{id}}}' \
   -f proj="{PROJECT_ID}" -f item="$ITEM_ID" \
-  -f field="{STORY_ID_FIELD_ID}" -f val="{PREFIX}-{NNN}"
+  -f field="{STORY_ID_FIELD_ID}" -f val="{PREFIX}-{ISSUE_NUMBER}"
 ```
 
 All `{...}` placeholders come from `CLAUDE.md` → "Work Tracking" section. If `CLAUDE.md` does not have field IDs, query them dynamically:
@@ -349,7 +352,7 @@ If the user describes another issue, loop back to **Phase 1**.
 Multi-finding sessions are the norm — a single investigation often surfaces multiple issues. Each gets its own ticket.
 
 ---
-<!-- skill-version: 5.2 -->
+<!-- skill-version: 5.3 -->
 <!-- last-updated: 2026-06-28 -->
 <!-- pipeline: v5 -->
 <!-- pipeline: v4 -->

--- a/standards/engineering-discipline.md
+++ b/standards/engineering-discipline.md
@@ -45,6 +45,11 @@ with the Test Rules in [testing.md](testing.md).
 | ED-2 | **Adversarial self-review.** Before finalizing, treat your *own just-produced* output as a suspect to cross-examine, not a product to defend. Re-trace each asserted data flow / type / contract to source and try to prove it wrong. | Before any spec/ticket/PR is finalized |
 | ED-3 | **Hypothesis vs. conclusion labeling.** A claim that is *not yet* grounded is written as a hypothesis with the evidence needed to settle it ("assumed; evidence needed: pull `X`"), never as established fact. | Whenever a claim can't be grounded *now* |
 | ED-4 | **Scope-fork detection.** Check whether the chosen approach silently changes blast radius or which test tiers apply. Surface the fork explicitly; never let a ticket hide it. | When picking an approach |
+| ED-5 | **Proactive contribution, surfaced last.** Before finalizing a ticket, volunteer your own take to the human — *what we missed / what we should consider / what I'd add* (plus what you considered and set aside) — **automatically, without being asked**. It is a **mandatory terminal deliverable**: surface it as the *last* thing you do, as (or as part of) the final report — never mid-task. A required user-facing step that produces no artifact and isn't the terminal output gets skipped under wrap-up momentum, so it must *be* the wrap-up. Headless/orchestrator mode (no human): fold the same items into the issue/ticket instead. | When producing or refining a ticket / backlog |
+
+## Why ED-5 is structured as a terminal deliverable
+
+The failure ED-5 prevents is subtle: an instance runs the *silent* half of the work (the adversarial self-review, ED-2), updates the issue, and reports "done" — letting the internal review stand in for the user-facing contribution. The contribution is the only output that produces no durable artifact (it's a conversational message, not an issue edit), so under "produce artifacts, report status" momentum it is exactly the step that falls through. The fix is positional, not motivational: make the contribution the terminal output so that *reporting status* cannot happen without it. "Interactive-mode-only" framing or a mid-skill position invites the skip; being the last thing you do prevents it.
 
 ## How the rules combine
 


### PR DESCRIPTION
Two ticket-producer corrections found this session, on one branch (both touch the same skills, so separate branches would collide).

## 1. ED-5 — proactive contribution as a mandatory terminal deliverable
**Failure (HeyCAPTO HC-479):** refinement skipped the user-facing three-part contribution; the user had to ask. Root cause is structural — the contribution is the only output with no durable artifact and it sat mid-skill, so "issue updated, report done" momentum swallowed it. (The other instance's "save it to memory" wouldn't help — memory doesn't propagate.)
- New standard rule **ED-5** in `engineering-discipline.md`: surface the contribution **last**, as/with the final report, never mid-task.
- `refine-story-v5`: prepare in 3.5, **deliver in 4e** as the terminal output; `CONTRIBUTION_SURFACED` in the report.
- `add-story` / `prd-to-backlog` / `triage` / `reconcile-backlog`: ED-5 framing (mandatory, not skippable) at the contribution checkpoint + a backstop in each final report.
- `CLAUDE.md` ED-5 bullet; the five ticket-producers widen to ED-1..ED-5 (implement/review/security stay ED-1..ED-4).

## 2. triage ticket numbering
`triage-v5` uniquely never prefixed the issue **title** with the Story ID (add-story/prd both do `--title "{PREFIX}-{ISSUE_NUM}: {Title}"`), and its board Story ID **field** used a stale `{NNN}` placeholder the backfill never fills. So triage tickets showed no `HC-###` in the title (the most visible place) or on the board.
- Add the title-prefix edit in the post-create block; fix the field value to `{PREFIX}-{ISSUE_NUMBER}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)